### PR TITLE
#4 Add Namecheap implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The following providers are currently implemented:
   - [NIRA](https://nira.ng/become-a-registrar)
   - [Ricta](https://www.ricta.org.rw/become-a-registrar/)
   - [UGRegistry](https://registry.co.ug/docs/v2/)
+  - [Namecheap](https://www.namecheap.com/support/api/methods/)
 
 ## Functions
 

--- a/src/Data/RenewParams.php
+++ b/src/Data/RenewParams.php
@@ -21,7 +21,7 @@ class RenewParams extends DataSet
         return new Rules([
             'sld' => ['required', 'alpha-dash'],
             'tld' => ['required', 'alpha-dash-dot'],
-            'renew_years' => ['required', 'integer', 'max:10'],
+            'renew_years' => ['required', 'integer', 'min:1', 'max:10'],
         ]);
     }
 }

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -7,6 +7,7 @@ namespace Upmind\ProvisionProviders\DomainNames;
 use Upmind\ProvisionBase\Laravel\ProvisionServiceProvider;
 use Upmind\ProvisionProviders\DomainNames\Category as DomainNames;
 use Upmind\ProvisionProviders\DomainNames\Example\Provider as ExampleProvider;
+use Upmind\ProvisionProviders\DomainNames\Namecheap\Provider as Namecheap;
 use Upmind\ProvisionProviders\DomainNames\Nominet\Provider as Nominet;
 use Upmind\ProvisionProviders\DomainNames\Hexonet\Provider as Hexonet;
 use Upmind\ProvisionProviders\DomainNames\Enom\Provider as Enom;
@@ -48,5 +49,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('domain-names', 'ricta', Ricta::class);
         $this->bindProvider('domain-names', 'ug-registry', UGRegistry::class);
         $this->bindProvider('domain-names', 'domain-name-api', DomainNameApi::class);
+        $this->bindProvider('domain-names', 'namecheap', Namecheap::class);
     }
 }

--- a/src/Namecheap/Data/NamecheapConfiguration.php
+++ b/src/Namecheap/Data/NamecheapConfiguration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Namecheap\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * Example configuration.
+ *
+ * @property-read string $username Login id
+ * @property-read string $api_token API token
+ * @property-read bool|null $sandbox Make API requests against the sandbox environment
+ * @property-read bool|null $debug Whether or not to log API requests and responses
+ */
+class NamecheapConfiguration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'username'  => ['required', 'string', 'min:3', 'max:20'],
+            'api_token' => ['required', 'string', 'min:6', 'max:50'],
+            'sandbox'   => ['nullable', 'boolean'],
+            'debug'     => ['nullable', 'boolean'],
+        ]);
+    }
+}

--- a/src/Namecheap/Helper/NamecheapApi.php
+++ b/src/Namecheap/Helper/NamecheapApi.php
@@ -1,0 +1,602 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Namecheap\Helper;
+
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use SimpleXMLElement;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactData;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacDomain;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Upmind\ProvisionProviders\DomainNames\Namecheap\Data\NamecheapConfiguration;
+
+/**
+ * Class NamecheapCommand
+ *
+ * @package Upmind\ProvisionProviders\DomainNames\Namecheap\Helper
+ */
+class NamecheapApi
+{
+    /**
+     * Allowed contact types
+     */
+    protected const ALLOWED_CONTACT_TYPES = ['registrant', 'tech', 'admin', 'auxbilling'];
+
+    public const NO_LOCK_TLDS = [
+        'io',
+    ];
+
+    public const TRANSFER_TLD = [
+        "biz", "ca", "cc", "co",
+        "co.uk", "com", "com.es", "com.pe",
+        "es", "in", "info", "me",
+        "me.uk", "mobi", "net", "net.pe",
+        "nom.es", "org", "org.es", "org.pe",
+        "org.uk", "pe", "tv", "us",
+    ];
+
+    /**
+     * Contact Types
+     */
+    public const CONTACT_TYPE_REGISTRANT = 'Registrant';
+    public const CONTACT_TYPE_TECH = 'Tech';
+    public const CONTACT_TYPE_ADMIN = 'Admin';
+    public const CONTACT_TYPE_BILLING = 'AuxBilling';
+
+    protected Client $client;
+
+    protected NamecheapConfiguration $configuration;
+
+    public function __construct(Client $client, NamecheapConfiguration $configuration)
+    {
+        $this->client = $client;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @param  string  $domainList
+     *
+     * @return array
+     */
+    public function checkMultipleDomains(string $domainList): array
+    {
+        $params = [
+            'command'    => 'namecheap.domains.check',
+            'DomainList' => $domainList,
+        ];
+
+        $response = $this->makeRequest($params);
+
+        $dacDomains = [];
+
+        foreach ($response->children() as $domain) {
+            $domainName = (string) $domain->attributes()->Domain;
+
+            $available = (string) $domain->attributes()->Available === "true";
+
+            $canTransfer = false;
+
+            if (!$available) {
+                $canTransfer = !$this->getRegistrarLockStatus($domainName);
+            }
+
+            $dacDomains[] = DacDomain::create([
+                'domain'       => $domainName,
+                'description'  => sprintf(
+                    'Domain is %s to register',
+                    $available ? 'available' : 'not available'
+                ),
+                'tld'          => Utils::getTld($domainName),
+                'can_register' => $available,
+                'can_transfer' => $canTransfer,
+                'is_premium'   => $domain->attributes()->IsPremiumName === "true",
+            ]);
+        }
+
+        return $dacDomains;
+    }
+
+    /**
+     * @param  string  $domainName
+     * @param  int  $years
+     * @param  array  $contacts
+     * @param  string  $nameServers
+     *
+     * @return void
+     */
+    public function register(string $domainName, int $years, array $contacts, string $nameServers): void
+    {
+        $params = [
+            'command'     => 'namecheap.domains.create',
+            'DomainName'  => $domainName,
+            'Years'       => $years,
+            'Nameservers' => $nameServers,
+        ];
+
+        foreach ($contacts as $type => $contact) {
+            $contactParams = $this->setContactParams($contact, $type);
+            $params = array_merge($params, $contactParams);
+        }
+
+        $this->makeRequest($params);
+    }
+
+    /**
+     * @param  string  $domainName
+     * @param  string  $eppCode
+     *
+     * @return string
+     */
+    public function initiateTransfer(string $domainName, string $eppCode): string
+    {
+        $params = [
+            'command'    => 'namecheap.domains.transfer.create',
+            'DomainName' => $domainName,
+            'EPPCode'    => 'base64:'.base64_encode($eppCode),
+            'Years'      => 1,
+        ];
+
+        $response = $this->makeRequest($params)->DomainTransferCreateResult;
+
+        return (string) $response->attributes()->TransferID;
+    }
+
+    /**
+     * @param  string  $domainName
+     * @param  int  $period
+     *
+     * @return void
+     */
+    public function renew(string $domainName, int $period): void
+    {
+        $params = [
+            'command'    => 'namecheap.domains.renew',
+            'DomainName' => $domainName,
+            'Years'      => $period,
+        ];
+
+        $this->makeRequest($params);
+    }
+
+    /**
+     * @param  string  $domainName
+     *
+     * @return array
+     */
+    public function getDomainInfo(string $domainName): array
+    {
+        $params = [
+            'command'    => 'namecheap.domains.getinfo',
+            'DomainName' => $domainName,
+        ];
+
+        $response = $this->makeRequest($params)->DomainGetInfoResult;
+        $lock = $this->getRegistrarLockStatus($domainName);
+        $contacts = $this->getContacts($domainName);
+
+        $status = (string) $response->attributes()->Status;
+
+        return [
+            'id'         => (string) $response->attributes()->ID,
+            'domain'     => (string) $response->attributes()->DomainName,
+            'statuses'   => [$status === "Ok" ? 'Active' : $status],
+            'locked'     => $lock,
+            'registrant' => $this->parseContact($contacts->Registrant, self::CONTACT_TYPE_REGISTRANT),
+            'billing'    => $this->parseContact($contacts->AuxBilling, self::CONTACT_TYPE_BILLING),
+            'tech'       => $this->parseContact($contacts->Tech, self::CONTACT_TYPE_TECH),
+            'admin'      => $this->parseContact($contacts->Admin, self::CONTACT_TYPE_ADMIN),
+            'ns'         => NameserversResult::create($this->parseNameservers($response->DnsDetails)),
+            'created_at' => Utils::formatDate((string) $response->DomainDetails->CreatedDate),
+            'updated_at' => null,
+            'expires_at' => Utils::formatDate((string) $response->DomainDetails->ExpiredDate),
+        ];
+    }
+
+    /**
+     * @param  string  $domainName
+     * @param  ContactParams  $contactParams
+     *
+     * @return array
+     */
+    public function updateRegistrantContact(string $domainName, ContactParams $contactParams): array
+    {
+        $currentContacts = $this->getContacts($domainName);
+
+        $registrantParams = $this->setContactParams($contactParams, self::CONTACT_TYPE_REGISTRANT);
+        $techParams = $this->setXMLContactParams($currentContacts->Tech, self::CONTACT_TYPE_TECH);
+        $adminParams = $this->setXMLContactParams($currentContacts->Admin, self::CONTACT_TYPE_ADMIN);
+        $auxBillingParams = $this->setXMLContactParams($currentContacts->AuxBilling, self::CONTACT_TYPE_BILLING);
+
+        $params = [
+            'command'    => 'namecheap.domains.setContacts',
+            'DomainName' => $domainName,
+        ];
+
+        $params = array_merge($params, $registrantParams, $techParams, $adminParams, $auxBillingParams);
+
+        $this->makeRequest($params);
+
+        $result = [
+            'organisation' => $contactParams->organisation ?: '-',
+            'name'         => $contactParams->name,
+            'address1'     => $contactParams->address1,
+            'city'         => $contactParams->city,
+            'state'        => $contactParams->state ?: '-',
+            'postcode'     => $contactParams->postcode,
+            'country_code' => Utils::normalizeCountryCode($contactParams->country_code),
+            'email'        => $contactParams->email,
+            'phone'        => $contactParams->phone,
+        ];
+
+        if (isset($contactParams->organisation)) {
+            $result['organisation'] = $contactParams->organisation;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  string  $sld
+     * @param  string  $tld
+     * @param  string  $nameservers
+     *
+     * @return array
+     */
+    public function updateNameservers(string $sld, string $tld, string $nameservers): array
+    {
+        $command = 'namecheap.domains.dns.setCustom';
+
+        if ($nameservers === "") {
+            $command = 'namecheap.domains.dns.setDefault';
+        }
+
+        $params = [
+            'command'     => $command,
+            'SLD'         => $sld,
+            'TLD'         => $tld,
+            'NameServers' => $nameservers,
+        ];
+
+        $this->makeRequest($params);
+
+        $ns = $this->getDNSList($sld, $tld);
+
+        return $this->parseNameservers($ns);
+    }
+
+    /**
+     * Send request and return the response.
+     *
+     * @param  string  $domainName
+     * @param  bool  $lock
+     *
+     * @return void
+     */
+    public function setRegistrarLock(string $domainName, bool $lock): void
+    {
+        $params = [
+            'command'    => 'namecheap.domains.setRegistrarLock',
+            'DomainName' => $domainName,
+            'LockAction' => $lock ? "lock" : "unlock",
+        ];
+
+        $this->makeRequest($params);
+    }
+
+    /**
+     * @param  string  $sld
+     * @param  string  $tld
+     *
+     * @return SimpleXMLElement
+     */
+    private function getDNSList(string $sld, string $tld): SimpleXMLElement
+    {
+        $params = [
+            'command' => 'namecheap.domains.dns.getList',
+            'SLD'     => $sld,
+            'TLD'     => $tld,
+        ];
+
+        return $this->makeRequest($params)->DomainDNSGetListResult;
+    }
+
+    /**
+     * @param  string  $domainName
+     *
+     * @return bool
+     */
+    public function getRegistrarLockStatus(string $domainName): bool
+    {
+        $params = [
+            'command'    => 'namecheap.domains.getRegistrarLock',
+            'DomainName' => $domainName,
+        ];
+
+        $tld = Utils::getTld($domainName);
+
+        if (in_array($tld, self::NO_LOCK_TLDS)) {
+            return false;
+        }
+
+        $response = $this->makeRequest($params);
+        $lockStatus = (string) $response->DomainGetRegistrarLockResult->attributes()->RegistrarLockStatus;
+
+        return $lockStatus === "true";
+    }
+
+    /**
+     * @param  string  $domainName
+     *
+     * @return SimpleXMLElement
+     */
+    private function getContacts(string $domainName): SimpleXMLElement
+    {
+        $params = [
+            'command'    => 'namecheap.domains.getContacts',
+            'DomainName' => $domainName,
+        ];
+
+        return $this->makeRequest($params)->DomainContactsResult;
+    }
+
+    /**
+     * @param  string  $domainName
+     *
+     * @return array|null
+     */
+    public function getDomainTransferOrders(string $domainName): ?array
+    {
+        $params = [
+            'command'    => 'namecheap.domains.transfer.getlist',
+            'SearchTerm' => $domainName,
+            'ListType'   => 'INPROGRESS',
+        ];
+
+        $response = $this->makeRequest($params);
+        $orderCount = (int) $response->Paging->TotalItems;
+
+        $orders = [];
+
+        if ($orderCount > 0) {
+            foreach ($response->TransferGetListResult->children() as $order) {
+                $orders[] = [
+                    'orderId'  => (string) $order->attributes()->OrderID,
+                    'status'   => (string) $order->attributes()->Status,
+                    'statusId' => (int) $order->attributes()->StatusID,
+                    'date'     => Utils::formatDate((string) $order->attributes()->StatusDate),
+                ];
+            }
+
+            if (count($orders) > 0) {
+                return $orders;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Send request and return the response.
+     *
+     * @param  array  $params
+     *
+     * @return SimpleXMLElement
+     *
+     * @throws ProvisionFunctionError
+     */
+    public function makeRequest(array $params): SimpleXMLElement
+    {
+        // Prepare command params
+        $params = array_merge([
+            'ApiUser'  => $this->configuration->username,
+            'ApiKey'   => $this->configuration->api_token,
+            'UserName' => $this->configuration->username,
+            'ClientIp' => request()->server('SERVER_ADDR'),
+        ], $params);
+
+        $response = $this->client->get('/xml.response', ['query' => $params]);
+
+        $result = $response->getBody()->__toString();
+        $response->getBody()->close();
+
+        if (empty($result)) {
+            throw new RuntimeException('Empty Namecheap api response');
+        }
+
+        return $this->parseResponseData($result);
+    }
+
+    /**
+     * Parse and process the XML Response
+     *
+     * @param  string  $result
+     *
+     * @return SimpleXMLElement
+     * @throws ProvisionFunctionError
+     */
+    private function parseResponseData(string $result): SimpleXMLElement
+    {
+        // Try to parse the response
+        $xml = simplexml_load_string($result, 'SimpleXMLElement', LIBXML_NOCDATA);
+
+        if ($xml === false) {
+            throw ProvisionFunctionError::create('Unknown Provider API Error')
+                ->withData([
+                    'response' => $result,
+                ]);
+        }
+
+        // Check the XML for errors
+        if ($errors = $this->parseXmlError($xml->Errors)) {
+            throw ProvisionFunctionError::create($this->formatNamecheapErrorMessage($errors))
+                ->withData([
+                    'response' => $xml,
+                ]);
+        }
+
+        if (empty($xml->CommandResponse)) {
+            throw ProvisionFunctionError::create('No CommandResponse found')
+                ->withData([
+                    'response' => $result,
+                ]);
+        }
+
+        return $xml->CommandResponse;
+    }
+
+    /**
+     * @param  array  $xmlErrors
+     *
+     * @return string
+     */
+    private function formatNamecheapErrorMessage(array $xmlErrors): string
+    {
+        $errors = [];
+
+        foreach ($xmlErrors as $error) {
+            switch ($error->attributes()->Number) {
+                case 1011150:
+                    $errors[] = 'Rejected request - please review whitelisted IPs';
+                    break;
+                default:
+                    $errors[] = (string) $error;
+                    break;
+            }
+        }
+
+        return sprintf("Provider API Errors: %s", implode(', ', $errors));
+    }
+
+    private function parseXmlError(SimpleXMLElement $errors): array
+    {
+        $result = [];
+
+        foreach ($errors->children() as $err) {
+            $result[] = $err;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  SimpleXMLElement  $contact
+     * @param  string  $type
+     *
+     * @return ContactData
+     */
+    private function parseContact(SimpleXMLElement $contact, string $type): ContactData
+    {
+        // Check if our contact type is valid
+        self::validateContactType($type);
+
+        return ContactData::create([
+            'organisation' => (string) $contact->OrganizationName ?: '-',
+            'name'         => $contact->FirstName." ".$contact->LastName,
+            'address1'     => (string) $contact->Address1,
+            'city'         => (string) $contact->City,
+            'state'        => (string) $contact->StateProvince ?: '-',
+            'postcode'     => (string) $contact->PostalCode,
+            'country_code' => (string) $contact->Country,
+            'email'        => (string) $contact->EmailAddress,
+            'phone'        => (string) $contact->Phone,
+        ]);
+    }
+
+    /**
+     * @param  string  $type
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function validateContactType(string $type): void
+    {
+        if (!in_array(strtolower($type), self::ALLOWED_CONTACT_TYPES)) {
+            throw new InvalidArgumentException(sprintf('Invalid contact type %s used!', $type));
+        }
+    }
+
+    /**
+     * @param  SimpleXMLElement  $DnsDetails
+     *
+     * @return array
+     */
+    private function parseNameservers(SimpleXMLElement $DnsDetails): array
+    {
+        $result = [];
+        $i = 1;
+
+        foreach ($DnsDetails->children() as $ns) {
+            $result['ns'.$i] = ['host' => (string) $ns];
+            $i++;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  string|null  $name
+     *
+     * @return array
+     */
+    private function getNameParts(?string $name): array
+    {
+        $nameParts = explode(" ", $name);
+        $firstName = array_shift($nameParts);
+        $lastName = implode(" ", $nameParts);
+
+        return compact('firstName', 'lastName');
+    }
+
+    /**
+     * @param  SimpleXMLElement  $contact
+     * @param  string  $type
+     *
+     * @return array
+     */
+    private function setXMLContactParams(SimpleXMLElement $contact, string $type): array
+    {
+        return [
+            $type.'OrganizationName' => (string) $contact->OrganizationName ?: '-',
+            $type.'FirstName'        => (string) $contact->FirstName,
+            $type.'LastName'         => (string) $contact->LastName,
+            $type.'Address1'         => (string) $contact->Address1,
+            $type.'City'             => (string) $contact->City,
+            $type.'StateProvince'    => (string) $contact->StateProvince ?: '-',
+            $type.'PostalCode'       => (string) $contact->PostalCode,
+            $type.'Country'          => Utils::normalizeCountryCode((string) $contact->Country),
+            $type.'EmailAddress'     => (string) $contact->EmailAddress,
+            $type.'Phone'            => (string) $contact->Phone,
+        ];
+    }
+
+    /**
+     * @param  ContactParams  $contactParams
+     * @param  string  $type
+     *
+     * @return array
+     */
+    private function setContactParams(ContactParams $contactParams, string $type): array
+    {
+        $nameParts = $this->getNameParts($contactParams->name ?? $contactParams->organisation);
+
+        return [
+            $type.'OrganizationName' => $contactParams->organisation ?: '-',
+            $type.'FirstName'        => $nameParts['firstName'],
+            $type.'LastName'         => $nameParts['lastName'],
+            $type.'Address1'         => $contactParams->address1,
+            $type.'City'             => $contactParams->city,
+            $type.'StateProvince'    => $contactParams->state ?: '-',
+            $type.'PostalCode'       => $contactParams->postcode,
+            $type.'Country'          => Utils::normalizeCountryCode($contactParams->country_code),
+            $type.'EmailAddress'     => $contactParams->email,
+            $type.'Phone'            => $contactParams->phone,
+        ];
+    }
+}

--- a/src/Namecheap/Provider.php
+++ b/src/Namecheap/Provider.php
@@ -1,0 +1,502 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Namecheap;
+
+use ArrayAccess;
+use Throwable;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use GuzzleHttp\Client;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Log;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionBase\Provider\DataSet\ResultData;
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionProviders\DomainNames\Category as DomainNames;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppCodeResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppParams;
+use Upmind\ProvisionProviders\DomainNames\Data\IpsTagParams;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Data\RegisterDomainParams;
+use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\LockParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollResult;
+use Upmind\ProvisionProviders\DomainNames\Data\AutoRenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateDomainContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
+use Upmind\ProvisionProviders\DomainNames\Namecheap\Data\NamecheapConfiguration;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Upmind\ProvisionProviders\DomainNames\Namecheap\Helper\NamecheapApi;
+
+/**
+ * Class Provider
+ *
+ * @package Upmind\ProvisionProviders\DomainNames\Namecheap
+ */
+class Provider extends DomainNames implements ProviderInterface
+{
+    /**
+     * @var NamecheapConfiguration
+     */
+    protected NamecheapConfiguration $configuration;
+
+    /**
+     * @var NamecheapApi
+     */
+    protected NamecheapApi $api;
+
+    /**
+     * Min and max count of name servers that we can expect in a request
+     */
+    private const MIN_CUSTOM_NAMESERVERS = 2;
+    private const MAX_CUSTOM_NAMESERVERS = 5;
+
+    /**
+     * Common nameservers for Namecheap
+     */
+    private const DEFAULT_NAMESERVERS = [
+        'dns1.registrar-servers.com',
+        'dns2.registrar-servers.com',
+        'dns3.registrar-servers.com',
+        'dns4.registrar-servers.com',
+        'dns5.registrar-servers.com',
+    ];
+
+    /**
+     * @param  NamecheapConfiguration  $configuration
+     */
+    public function __construct(NamecheapConfiguration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @return AboutData
+     */
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('Namecheap')
+            ->setDescription('Registering, hosting, and managing Namecheap domains')
+            //TODO upload logo file
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/namecheap-logo.png');
+    }
+
+    /**
+     * @param  PollParams  $params
+     *
+     * @return PollResult
+     */
+    public function poll(PollParams $params): PollResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @param  DacParams  $params
+     *
+     * @return DacResult
+     */
+    public function domainAvailabilityCheck(DacParams $params): DacResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+        $domains = array_map(
+            fn($tld) => $sld.".".Utils::normalizeTld($tld),
+            $params->tlds
+        );
+        $domainList = rtrim(implode(",", $domains), ',');
+
+        $dacDomains = $this->api()->checkMultipleDomains($domainList);
+
+        return DacResult::create([
+            'domains' => $dacDomains,
+        ]);
+    }
+
+    /**
+     * @param  RegisterDomainParams  $params
+     *
+     * @return DomainResult
+     */
+    public function register(RegisterDomainParams $params): DomainResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+        $tld = Utils::normalizeTld($params->tld);
+        $domainName = Utils::getDomain($sld, $tld);
+
+        $this->checkRegisterParams($params);
+
+        $checkResult = $this->api()->checkMultipleDomains($domainName);
+
+        if (count($checkResult) < 1) {
+            throw $this->errorResult('Empty domain availability check result');
+        }
+
+        if (!$checkResult[0]->can_register) {
+            throw $this->errorResult('This domain is not available to register');
+        }
+
+        $contacts = [
+            NamecheapApi::CONTACT_TYPE_REGISTRANT => $params->registrant->register,
+            NamecheapApi::CONTACT_TYPE_ADMIN      => $params->admin->register,
+            NamecheapApi::CONTACT_TYPE_TECH       => $params->tech->register,
+            NamecheapApi::CONTACT_TYPE_BILLING    => $params->billing->register,
+        ];
+
+        try {
+            $this->api()->register(
+                $domainName,
+                intval($params->renew_years),
+                $contacts,
+                $this->prepareNameservers($params, 'nameservers.ns'),
+            );
+
+            return $this->_getInfo($domainName, sprintf('Domain %s was registered successfully!', $domainName));
+        } catch (\Throwable $e) {
+            $this->handleException($e, $params);
+        }
+    }
+
+    /**
+     * @param  RegisterDomainParams  $params
+     *
+     * @return void
+     */
+    private function checkRegisterParams(RegisterDomainParams $params): void
+    {
+        if (!Arr::has($params, 'registrant.register')) {
+            throw $this->errorResult('Registrant contact data is required!');
+        }
+
+        if (!Arr::has($params, 'tech.register')) {
+            throw $this->errorResult('Tech contact data is required!');
+        }
+
+        if (!Arr::has($params, 'admin.register')) {
+            throw $this->errorResult('Admin contact data is required!');
+        }
+
+        if (!Arr::has($params, 'billing.register')) {
+            throw $this->errorResult('Billing contact data is required!');
+        }
+    }
+
+
+    /**
+     * @param ArrayAccess $params
+     * @param string $prefix
+     * @return string
+     */
+    private function prepareNameservers(ArrayAccess $params, string $prefix): string
+    {
+        $nameServers = "";
+
+        $custom = 0;
+        $default = 0;
+
+        for ($i = 1; $i <= self::MAX_CUSTOM_NAMESERVERS; $i++) {
+            if (Arr::has($params, $prefix.$i)) {
+                $host = Arr::get($params, $prefix.$i)->host;
+                if (!in_array($host, self::DEFAULT_NAMESERVERS)) {
+                    $nameServers .= $host.",";
+                    $custom++;
+                } else {
+                    $default++;
+                }
+            }
+        }
+
+        if ($custom != 0 && $default != 0) {
+            throw $this->errorResult(
+                "It's not possible to mix Namecheap's default nameservers with other ones",
+                $params
+            );
+        }
+
+        if ($custom + $default < self::MIN_CUSTOM_NAMESERVERS) {
+            throw $this->errorResult('Minimum two nameservers are required!', $params);
+        }
+
+        return $nameServers;
+    }
+
+    /**
+     * @param  TransferParams  $params
+     *
+     * @return DomainResult
+     */
+    public function transfer(TransferParams $params): DomainResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+        $tld = Utils::normalizeTld($params->tld);
+
+        if (!in_array($tld, NamecheapApi::TRANSFER_TLD)) {
+            throw $this->errorResult(sprintf("Transfer is not available for TLD %s", $tld), $params);
+        }
+
+        $domainName = Utils::getDomain($sld, $tld);
+
+        $eppCode = $params->epp_code ?: '0000';
+
+        try {
+            return $this->_getInfo($domainName, 'Domain active in registrar account');
+        } catch (Throwable $e) {
+            // domain not active - continue below
+        }
+
+        try {
+            $prevOrder = $this->api()->getDomainTransferOrders($domainName);
+
+            if (is_null($prevOrder)) {
+                $transferId = $this->api()->initiateTransfer($domainName, $eppCode);
+
+                return DomainResult::create([
+                    'id'         => $transferId,
+                    'domain'     => $domainName,
+                    'ns'         => [],
+                    'statuses'   => [],
+                    'created_at' => null,
+                    'updated_at' => null,
+                    'expires_at' => null,
+                ])->setMessage(sprintf('Transfer for %s domain successfully created!', $domainName));
+            } else {
+                throw $this->errorResult(
+                    sprintf('Transfer order(s) for %s already exists!', $domainName),
+                    $prevOrder,
+                    $params
+                );
+            }
+        } catch (\Throwable $e) {
+            $this->handleException($e, $params);
+        }
+    }
+
+    /**
+     * @param  RenewParams  $params
+     *
+     * @return DomainResult
+     */
+    public function renew(RenewParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld),
+        );
+        $period = intval($params->renew_years);
+
+        try {
+            $this->api()->renew($domainName, $period);
+            return $this->_getInfo($domainName, sprintf('Renewal for %s domain was successful!', $domainName));
+        } catch (\Throwable $e) {
+            $this->handleException($e, $params);
+        }
+    }
+
+    /**
+     * @param  DomainInfoParams  $params
+     *
+     * @return DomainResult
+     */
+    public function getInfo(DomainInfoParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        try {
+            return $this->_getInfo($domainName, 'Domain data obtained');
+        } catch (\Throwable $e) {
+            $this->handleException($e, $params);
+        }
+    }
+
+    /**
+     * @param  UpdateDomainContactParams  $params
+     *
+     * @return ContactResult
+     */
+    public function updateRegistrantContact(UpdateDomainContactParams $params): ContactResult
+    {
+        try {
+            $contact = $this->api()
+                ->updateRegistrantContact(
+                    Utils::getDomain(
+                        Utils::normalizeSld($params->sld),
+                        Utils::normalizeTld($params->tld)
+                    ),
+                    $params->contact
+                );
+
+            return ContactResult::create($contact);
+        } catch (\Throwable $e) {
+            $this->handleException($e, $params);
+        }
+    }
+
+    /**
+     * @param  UpdateNameserversParams  $params
+     *
+     * @return NameserversResult
+     */
+    public function updateNameservers(UpdateNameserversParams $params): NameserversResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+        $tld = Utils::normalizeTld($params->tld);
+
+        $domainName = Utils::getDomain($sld, $tld);
+
+        $nameServers = $this->prepareNameservers($params, 'ns');
+
+        try {
+            $result = $this->api()->updateNameservers(
+                $sld,
+                $tld,
+                $nameServers,
+            );
+
+            return NameserversResult::create($result)
+                ->setMessage(sprintf('Name servers for %s domain were updated!', $domainName));
+        } catch (\Throwable $e) {
+            $this->handleException($e, $params);
+        }
+    }
+
+    /**
+     * @param  LockParams  $params
+     *
+     * @return DomainResult
+     */
+    public function setLock(LockParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+        $lock = !!$params->lock;
+
+        try {
+            if (in_array($params->tld, NamecheapApi::NO_LOCK_TLDS)) {
+                throw $this->errorResult(
+                    sprintf('Domain %s does not support to change Registrar Lock.', $domainName),
+                    $params
+                );
+            }
+
+            $currentLockStatus = $this->api()->getRegistrarLockStatus($domainName);
+            if (!$lock && !$currentLockStatus) {
+                throw $this->errorResult(sprintf('Domain %s already unlocked', $domainName), $params);
+            }
+
+            if ($lock && $currentLockStatus) {
+                throw $this->errorResult(sprintf('Domain %s already locked', $domainName), $params);
+            }
+
+            $this->api()->setRegistrarLock($domainName, $lock);
+
+            return $this->_getInfo($domainName, sprintf("Lock %s!", $lock ? 'enabled' : 'disabled'));
+        } catch (\Throwable $e) {
+            $this->handleException($e, $params);
+        }
+    }
+
+    /**
+     * @param  AutoRenewParams  $params
+     *
+     * @return DomainResult
+     */
+    public function setAutoRenew(AutoRenewParams $params): DomainResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @param  EppParams  $params
+     *
+     * @return EppCodeResult
+     */
+    public function getEppCode(EppParams $params): EppCodeResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @param  IpsTagParams  $params
+     *
+     * @return ResultData
+     */
+    public function updateIpsTag(IpsTagParams $params): ResultData
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @return no-return
+     * @throws ProvisionFunctionError
+     */
+    protected function handleException(Throwable $e, $params = null): void
+    {
+        if (!$e instanceof ProvisionFunctionError) {
+            $e = new ProvisionFunctionError('Unexpected Provider Error', $e->getCode(), $e);
+        }
+
+        throw $e->withDebug([
+            'params' => $params,
+        ]);
+    }
+
+    /**
+     * @param  string  $domainName
+     * @param  string  $message
+     *
+     * @return DomainResult
+     */
+    private function _getInfo(string $domainName, string $message): DomainResult
+    {
+        $domainInfo = $this->api()->getDomainInfo($domainName);
+
+        return DomainResult::create($domainInfo)->setMessage($message);
+    }
+
+    /**
+     * @return NamecheapApi
+     */
+    protected function api(): NamecheapApi
+    {
+        if (isset($this->api)) {
+            return $this->api;
+        }
+
+        $client = new Client([
+            'base_uri'        => $this->resolveAPIURL(),
+            'headers'         => [
+                'User-Agent' => 'Upmind/ProvisionProviders/DomainNames/Namecheap',
+            ],
+            'connect_timeout' => 10,
+            'timeout'         => 60,
+            'verify'          => !$this->configuration->sandbox,
+            'handler'         => $this->getGuzzleHandlerStack(boolval($this->configuration->debug)),
+        ]);
+
+        return $this->api = new NamecheapApi($client, $this->configuration);
+    }
+
+    /**
+     * @return string
+     */
+    private function resolveAPIURL(): string
+    {
+        return $this->configuration->sandbox
+            ? 'https://api.sandbox.namecheap.com'
+            : 'https://api.namecheap.com';
+    }
+}


### PR DESCRIPTION
The following operations are implemented for Namecheap:

1. domainAvailabilityCheck()
2. register()
3. transfer()
4. renew()
5. getInfo()
6. updateRegistrantContact()
7. updateNameservers()
8. setLock()

The following operations aren't supported:

1. poll() - the operation isn't supported by Namecheap
2. setAutoRenew() - the operation isn't available via Namecheap's API, only via GUI
3. getEppCode() -  the operation isn't available via Namecheap's API, only via GUI
4. updateIpsTag() - the operation isn't supported by Namecheap