### PR TITLE
Add CentralNIC implementation

### DIFF
--- a/src/CentralNic/Data/Configuration.php
+++ b/src/CentralNic/Data/Configuration.php
@@ -10,7 +10,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
 /**
  * Example configuration.
  *
- * @property-read string $username
+ * @property-read string $registrar_handle_id
  * @property-read string $password
  * @property-read bool|null $sandbox
  * @property-read bool|null $debug Whether or not to enable debug logging
@@ -21,7 +21,7 @@ class Configuration extends DataSet
     public static function rules(): Rules
     {
         return new Rules([
-            'username' => ['required', 'string', 'min:3'],
+            'registrar_handle_id' => ['required', 'string', 'min:3'],
             'password' => ['required', 'string', 'min:6'],
             'sandbox' => ['nullable', 'boolean'],
             'debug' => ['nullable', 'boolean'],

--- a/src/CentralNic/Data/Configuration.php
+++ b/src/CentralNic/Data/Configuration.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\CentralNic\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * Example configuration.
+ *
+ * @property-read string $username
+ * @property-read string $password
+ * @property-read bool|null $sandbox
+ * @property-read bool|null $debug Whether or not to enable debug logging
+ */
+class Configuration extends DataSet
+{
+
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'username' => ['required', 'string', 'min:3'],
+            'password' => ['required', 'string', 'min:6'],
+            'sandbox' => ['nullable', 'boolean'],
+            'debug' => ['nullable', 'boolean'],
+        ]);
+    }
+}

--- a/src/CentralNic/EppExtension/EppConnection.php
+++ b/src/CentralNic/EppExtension/EppConnection.php
@@ -19,7 +19,7 @@ class EppConnection extends BaseEppConnection
     /**
      * @var LoggerInterface
      */
-    protected $logger;
+    protected LoggerInterface $logger;
 
     /**
      * EppConnection constructor.
@@ -41,5 +41,34 @@ class EppConnection extends BaseEppConnection
         if (isset($logger)) {
             $this->logFile = '/dev/null';
         }
+    }
+
+    /**
+     * Writes a log message to the log file or PSR-3 logger.
+     *
+     * @inheritdoc
+     */
+    public function writeLog($text, $action)
+    {
+        if ($this->logging && isset($this->logger)) {
+            $message = $text;
+            $message = $this->hideTextBetween($message, '<clID>', '</clID>');
+            // Hide password in the logging
+            $message = $this->hideTextBetween($message, '<pw>', '</pw>');
+            $message = $this->hideTextBetween($message, '<pw><![CDATA[', ']]></pw>');
+            // Hide new password in the logging
+            $message = $this->hideTextBetween($message, '<newPW>', '</newPW>');
+            $message = $this->hideTextBetween($message, '<newPW><![CDATA[', ']]></newPW>');
+            // Hide domain password in the logging
+            $message = $this->hideTextBetween($message, '<domain:pw>', '</domain:pw>');
+            $message = $this->hideTextBetween($message, '<domain:pw><![CDATA[', ']]></domain:pw>');
+            // Hide contact password in the logging
+            $message = $this->hideTextBetween($message, '<contact:pw>', '</contact:pw>');
+            $message = $this->hideTextBetween($message, '<contact:pw><![CDATA[', ']]></contact:pw>');
+
+            $this->logger->debug(sprintf("CentralNic [%s]:\n %s", $action, trim($message)));
+        }
+
+        parent::writeLog($text, $action);
     }
 }

--- a/src/CentralNic/EppExtension/EppConnection.php
+++ b/src/CentralNic/EppExtension/EppConnection.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\CentralNic\EppExtension;
+
+use Metaregistrar\EPP\eppCreateContactResponse;
+use Metaregistrar\EPP\eppInfoContactRequest;
+use Metaregistrar\EPP\eppPollRequest;
+use Metaregistrar\EPP\eppConnection as BaseEppConnection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class EppConnection
+ * @package Upmind\ProvisionProviders\DomainNames\CentralNic\EppExtension
+ */
+class EppConnection extends BaseEppConnection
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * EppConnection constructor.
+     * @param bool $logging
+     * @param string|null $settingsFile
+     */
+    public function __construct(bool $logging = false, string $settingsFile = null)
+    {
+        // Call parent's constructor
+        parent::__construct($logging, $settingsFile);
+    }
+
+    /**
+     * Set a PSR-3 logger.
+     */
+    public function setPsrLogger(?LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+        if (isset($logger)) {
+            $this->logFile = '/dev/null';
+        }
+    }
+}

--- a/src/CentralNic/Helper/CentralNicApi.php
+++ b/src/CentralNic/Helper/CentralNicApi.php
@@ -80,7 +80,7 @@ class CentralNicApi
         return $this->lockedStatuses;
     }
 
-    public function poll(int $limit, ?object $since): array
+    public function poll(int $limit, ?Carbon $since): array
     {
         $notifications = [];
         $countRemaining = 0;
@@ -424,7 +424,7 @@ class CentralNicApi
         return $response->getDomainNameservers();
     }
 
-    private function createHost(string $host, string $ip = null): void
+    private function createHost(string $host, ?string $ip): void
     {
         $create = new eppCreateHostRequest(new eppHost($host, $ip));
 

--- a/src/CentralNic/Helper/CentralNicApi.php
+++ b/src/CentralNic/Helper/CentralNicApi.php
@@ -1,0 +1,519 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\CentralNic\Helper;
+
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use Illuminate\Support\Arr;
+use Upmind\ProvisionBase\Helper;
+use Metaregistrar\EPP\eppCheckDomainRequest;
+use Metaregistrar\EPP\eppCheckDomainResponse;
+use Metaregistrar\EPP\eppCheckRequest;
+use Metaregistrar\EPP\eppPollResponse;
+use Metaregistrar\EPP\eppPollRequest;
+use Metaregistrar\EPP\eppContact;
+use Metaregistrar\EPP\eppContactHandle;
+use Metaregistrar\EPP\eppContactPostalInfo;
+use Metaregistrar\EPP\eppCreateContactRequest;
+use Metaregistrar\EPP\eppCreateContactResponse;
+use Metaregistrar\EPP\eppCreateDomainRequest;
+use Metaregistrar\EPP\eppCreateDomainResponse;
+use Metaregistrar\EPP\eppCreateHostRequest;
+use Metaregistrar\EPP\eppCreateResponse;
+use Metaregistrar\EPP\eppDomain;
+use Metaregistrar\EPP\eppException;
+use Metaregistrar\EPP\eppHost;
+use Metaregistrar\EPP\eppInfoContactRequest;
+use Metaregistrar\EPP\eppInfoContactResponse;
+use Metaregistrar\EPP\eppInfoDomainRequest;
+use Metaregistrar\EPP\eppInfoDomainResponse;
+use Metaregistrar\EPP\eppRenewRequest;
+use Metaregistrar\EPP\eppRenewResponse;
+use Metaregistrar\EPP\eppTransferRequest;
+use Metaregistrar\EPP\eppTransferResponse;
+use Metaregistrar\EPP\eppUpdateContactRequest;
+use Metaregistrar\EPP\eppUpdateContactResponse;
+use Metaregistrar\EPP\eppUpdateDomainRequest;
+use Metaregistrar\EPP\eppUpdateDomainResponse;
+use Metaregistrar\EPP\eppUpdateResponse;
+use Metaregistrar\EPP\eppResponse;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\DataSet\SystemInfo;
+use Upmind\ProvisionProviders\DomainNames\CentralNic\EppExtension\EppConnection;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacDomain;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainContactInfo;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainNotification;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Upmind\ProvisionProviders\DomainNames\CentralNic\Data\Configuration;
+
+/**
+ * Class CentralNicHelper
+ *
+ * @package Upmind\ProvisionProviders\DomainNames\CentralNic\Helper
+ */
+class CentralNicApi
+{
+    protected EppConnection $connection;
+    protected Configuration $configuration;
+
+    protected const CONTACT_LOC = 'loc';
+    protected const CONTACT_INT = 'int';
+    protected const CONTACT_AUTO = 'auto';
+
+    protected array $lockedStatuses = [
+        'clientTransferProhibited',
+        'clientUpdateProhibited',
+        'clientDeleteProhibited',
+    ];
+
+    public function __construct(EppConnection $connection, Configuration $configuration)
+    {
+        $this->connection = $connection;
+        $this->configuration = $configuration;
+    }
+
+    public function getLockedStatuses(): array
+    {
+        return $this->lockedStatuses;
+    }
+
+    public function poll(int $limit, ?object $since): array
+    {
+        $notifications = [];
+        $countRemaining = 0;
+
+        /**
+         * Start a timer because there may be 1000s of irrelevant messages and we should try and avoid a timeout.
+         */
+        $timeLimit = 60; // 60 seconds
+        $startTime = time();
+
+        while (count($notifications) < $limit && (time() - $startTime) < $timeLimit) {
+            // get oldest message from queue
+            /** @var eppPollResponse $pollResponse */
+            $pollResponse = $this->connection->request(new eppPollRequest(eppPollRequest::POLL_REQ, 0));
+            $countRemaining = $pollResponse->getMessageCount();
+
+            if ($countRemaining == 0) {
+                break;
+            }
+
+            $messageId = $pollResponse->getMessageId();
+            $type = $pollResponse->getMessageType();
+            $message = $pollResponse->getMessage() ?: 'Domain Notification';
+            $domain = $pollResponse->getDomainName();
+            $messageDateTime = Carbon::parse($pollResponse->getMessageDate());
+
+            $this->connection->request(new eppPollRequest(eppPollRequest::POLL_ACK, $messageId));
+
+            if ($type != eppPollResponse::TYPE_TRANSFER) {
+                // this message is irrelevant
+                continue;
+            }
+
+            if (isset($since) && $messageDateTime->lessThan($since)) {
+                // this message is too old
+                continue;
+            }
+
+            $notifications[] = DomainNotification::create()
+                ->setId($messageId)
+                ->setType(DomainNotification::TYPE_TRANSFER_IN)
+                ->setMessage($message)
+                ->setDomains([$domain])
+                ->setCreatedAt($messageDateTime)
+                ->setExtra(['xml' => $pollResponse->saveXML()]);
+        }
+
+        return [
+            'count_remaining' => $countRemaining,
+            'notifications' => $notifications,
+        ];
+    }
+
+    public function checkMultipleDomains(array $domains): array
+    {
+        $check = new eppCheckDomainRequest($domains);
+
+        /** @var eppCheckDomainResponse */
+        $response = $this->connection->request($check);
+
+        $checks = $response->getCheckedDomains();
+
+        $result = [];
+
+        foreach ($checks as $check) {
+            $available = (bool)$check['available'] == "true";
+
+            $premium = false;
+            if (!$available && $check['reason'] == 'premium') {
+                $premium = true;
+            }
+
+            $result[] = DacDomain::create([
+                'domain' => $check['domainname'],
+                'description' => sprintf(
+                    'Domain is %s to register. %s',
+                    $available ? 'available' : 'not available',
+                    $check['reason'],
+                ),
+                'tld' => Utils::getTld($check['domainname']),
+                'can_register' => $available,
+                'can_transfer' => !$available,
+                'is_premium' => $premium,
+            ]);
+        }
+
+        return $result;
+    }
+
+    public function register(
+        string $domainName,
+        int    $period,
+        array  $contacts,
+        array  $nameServers
+    ): array
+    {
+        $domain = new eppDomain($domainName, $contacts[eppContactHandle::CONTACT_TYPE_REGISTRANT], [
+            new eppContactHandle($contacts[eppContactHandle::CONTACT_TYPE_ADMIN], eppContactHandle::CONTACT_TYPE_ADMIN),
+            new eppContactHandle($contacts[eppContactHandle::CONTACT_TYPE_TECH], eppContactHandle::CONTACT_TYPE_TECH),
+            new eppContactHandle($contacts[eppContactHandle::CONTACT_TYPE_BILLING], eppContactHandle::CONTACT_TYPE_BILLING)
+        ]);
+
+        $domain->setRegistrant(new eppContactHandle($contacts[eppContactHandle::CONTACT_TYPE_REGISTRANT]));
+
+        $domain->setAuthorisationCode(self::generateValidAuthCode());
+
+        $domain = $this->addNameServers($nameServers, $domain);
+
+        // Set Domain Period
+        $domain->setPeriod($period);
+        $domain->setPeriodUnit('y');
+
+        // Create the domain
+        $create = new eppCreateDomainRequest($domain);
+
+        /** @var eppCreateDomainResponse */
+        $response = $this->connection->request($create);
+
+        return [
+            'domain' => $response->getDomainName(),
+            'created_at' => Utils::formatDate($response->getDomainCreateDate()),
+            'expires_at' => Utils::formatDate($response->getDomainExpirationDate())
+        ];
+    }
+
+    public function initiateTransfer(string $domainName, string $eppCode, int $renewYears): eppTransferResponse
+    {
+        $domain = new eppDomain($domainName);
+
+        // Set EPP Code
+        if ($eppCode != null) {
+            $domain->setAuthorisationCode($eppCode);
+        }
+
+        $domain->setPeriod($renewYears);
+        $domain->setPeriodUnit('y');
+
+        $transferRequest = new eppTransferRequest(eppTransferRequest::OPERATION_REQUEST, $domain);
+
+        // Process Response
+        /** @var eppTransferResponse */
+        return $this->connection->request($transferRequest);
+    }
+
+    public function renew(string $domainName, int $period): void
+    {
+        $domainData = new eppDomain($domainName);
+        $domainData->setPeriod($period);
+        $domainData->setPeriodUnit('y');
+
+        $info = new eppInfoDomainRequest($domainData);
+        /** @var eppInfoDomainResponse $response */
+        $response = $this->connection->request($info);
+
+        $expiresAt = Utils::formatDate($response->getDomainExpirationDate(), 'Y-m-d');
+
+        $renewRequest = new eppRenewRequest($domainData, $expiresAt);
+
+        $this->connection->request($renewRequest);
+    }
+
+    public function getDomainInfo(string $domainName): array
+    {
+        $domain = new eppDomain($domainName);
+        $info = new eppInfoDomainRequest($domain);
+
+        /** @var eppInfoDomainResponse */
+        $response = $this->connection->request($info);
+
+        $registrantId = $response->getDomainRegistrant();
+        $billingId = $response->getDomainContact(eppContactHandle::CONTACT_TYPE_BILLING);
+        $techId = $response->getDomainContact(eppContactHandle::CONTACT_TYPE_TECH);
+        $adminId = $response->getDomainContact(eppContactHandle::CONTACT_TYPE_ADMIN);
+
+        return [
+            'id' => $response->getDomainId(),
+            'domain' => $response->getDomainName(),
+            'statuses' => $response->getDomainStatuses() ?? [],
+            'locked' => boolval(array_intersect($this->lockedStatuses, $response->getDomainStatuses())),
+            'registrant' => $registrantId ? $this->getContactInfo($registrantId) : null,
+            'billing' => $billingId ? $this->getContactInfo($billingId) : null,
+            'tech' => $techId ? $this->getContactInfo($techId) : null,
+            'admin' => $adminId ? $this->getContactInfo($adminId) : null,
+            'ns' => $this->parseNameServers($response->getDomainNameservers() ?? []),
+            'created_at' => Utils::formatDate($response->getDomainCreateDate()),
+            'updated_at' => Utils::formatDate($response->getDomainUpdateDate() ?: $response->getDomainCreateDate()),
+            'expires_at' => Utils::formatDate($response->getDomainExpirationDate()),
+        ];
+    }
+
+    public function updateRegistrantContact(string $domainName, ContactParams $params): DomainContactInfo
+    {
+        $contactID = $this->createContact($params);
+
+        $mod = new eppDomain($domainName);
+        $mod->setRegistrant(new eppContactHandle($contactID));
+
+        $update = new eppUpdateDomainRequest(
+            new eppDomain($domainName),
+            null,
+            null,
+            $mod
+        );
+
+        /** @var eppUpdateDomainResponse $response */
+        $this->connection->request($update);
+
+        return $this->getContactInfo($contactID);
+    }
+
+    public function updateNameServers(
+        string $domainName,
+        array  $nameservers
+    ): string
+    {
+        // If new nameservers are given, get the old ones to remove them
+        $hosts = [];
+        foreach ($nameservers as $nameserver) {
+            $hosts[] = $nameserver['host'];
+        }
+
+        $oldNameservers = $this->getHosts($domainName);
+        if ($oldNameservers) {
+            $removeInfo = new eppDomain($domainName);
+
+            foreach ($oldNameservers as $ns) {
+                if (in_array($ns->getHostname(), $hosts)) {
+                    continue;
+                }
+
+                $removeInfo->addHost(new eppHost($ns->getHostname()));
+            }
+        }
+
+        $addInfo = new eppDomain($domainName);
+        $addInfo = $this->addNameServers($nameservers, $addInfo);
+
+        $update = new eppUpdateDomainRequest(
+            new eppDomain($domainName),
+            $addInfo,
+            $removeInfo ?? null,
+            $updateInfo ?? null
+        );
+
+        /** @var eppUpdateDomainResponse $response */
+        $response = $this->connection->request($update);
+
+        return $response->getResultMessage();
+    }
+
+    public function setRegistrarLock(string $domainName, array $addStatuses, array $removeStatuses): void
+    {
+        if (count($addStatuses)) {
+            $add = new eppDomain($domainName);
+            foreach ($addStatuses as $status) {
+                $add->addStatus($status);
+            }
+        }
+
+        if (count($removeStatuses)) {
+            $del = new eppDomain($domainName);
+            foreach ($removeStatuses as $status) {
+                $del->addStatus($status);
+            }
+        }
+
+        $domain = new eppDomain($domainName);
+        $update = new eppUpdateDomainRequest($domain, $add ?? null, $del ?? null);
+
+        $this->connection->request($update);
+    }
+
+    public function getContactInfo(string $contactId): DomainContactInfo
+    {
+        $request = new eppInfoContactRequest(new eppContactHandle($contactId), false);
+        /** @var eppInfoContactResponse */
+        $response = $this->connection->request($request);
+
+        return DomainContactInfo::create([
+            'contact_id' => $contactId,
+            'name' => $response->getContactName(),
+            'email' => $response->getContactEmail(),
+            'phone' => $response->getContactVoice(),
+            'organisation' => $response->getContactCompanyname(),
+            'address1' => $response->getContactStreet(),
+            'city' => $response->getContactCity(),
+            'state' => $response->getContactProvince(),
+            'postcode' => $response->getContactZipcode(),
+            'country_code' => $response->getContactCountrycode(),
+            'type' => $response->getContact()->getType(),
+        ]);
+    }
+
+    private function parseNameServers(array $nameServers): array
+    {
+        $result = [];
+
+        if (count($nameServers) > 0) {
+            foreach ($nameServers as $i => $ns) {
+                $result['ns' . ($i + 1)] = [
+                    'host' => $ns->getHostName(),
+                    'ip' => $ns->getIpAddresses()
+                ];
+            }
+        }
+
+        return $result;
+    }
+
+    public function getRegistrarLockStatuses(string $domainName): array
+    {
+        $domain = new eppDomain($domainName);
+        $info = new eppInfoDomainRequest($domain);
+
+        /** @var eppInfoDomainResponse */
+        $response = $this->connection->request($info);
+
+        return $response->getDomainStatuses();
+    }
+
+    public function getDomainEppCode(string $domainName): ?string
+    {
+        $domain = new eppDomain($domainName);
+
+        $info = new eppInfoDomainRequest($domain);
+
+        /** @var eppInfoDomainResponse $response */
+        $response = $this->connection->request($info);
+
+        return $response->getDomainAuthInfo();
+    }
+
+    public function getHosts(string $domainName): ?array
+    {
+        $domain = new eppDomain($domainName);
+        $info = new eppInfoDomainRequest($domain);
+
+        /** @var eppInfoDomainResponse */
+        $response = $this->connection->request($info);
+
+        return $response->getDomainNameservers();
+    }
+
+    private function createHost(string $host, string $ip = null): void
+    {
+        $create = new eppCreateHostRequest(new eppHost($host, $ip));
+
+        /** @var eppCreateHostResponse */
+        $this->connection->request($create);
+    }
+
+    /**
+     * Generates a random auth code containing lowercase letters, uppercase letters, numbers and special characters.
+     *
+     * @return string
+     */
+    private static function generateValidAuthCode(int $length = 16): string
+    {
+        return Helper::generateStrictPassword($length, true, true, true, '!@#$%^*_');
+    }
+
+    public function createContact(ContactParams $params): string
+    {
+        $telephone = null;
+        if ($params->phone) {
+            $telephone = Utils::internationalPhoneToEpp($params->phone);
+        }
+
+        $countryCode = null;
+        if ($params->country_code) {
+            $countryCode = Utils::normalizeCountryCode($params->country_code);
+        }
+
+        $eppContactType = $params->type;
+
+        if (!in_array($eppContactType, [self::CONTACT_LOC, self::CONTACT_INT, self::CONTACT_AUTO])) {
+            $eppContactType = self::CONTACT_AUTO;
+        }
+
+        $postalInfo = new eppContactPostalInfo(
+            $params->name ?: $params->organisation,
+            $params->city,
+            $countryCode,
+            $params->organisation,
+            $params->address1,
+            $params->state,
+            $params->postcode
+        );
+
+        $contactInfo = new eppContact($postalInfo, $params->email, $telephone);
+
+        $contactInfo->setType($eppContactType);
+        $contactInfo->setPassword($params->password ?? self::generateValidAuthCode());
+
+        $contact = new eppCreateContactRequest($contactInfo);
+
+        /** @var eppCreateContactResponse $response */
+        $response = $this->connection->request($contact);
+
+        return $response->getContactId();
+    }
+
+    private function addNameServers(array $nameservers, eppDomain $domain): eppDomain
+    {
+        $uncreatedHosts = $this->checkUncreatedHosts($nameservers);
+
+        foreach ($nameservers as $nameserver) {
+            if (!empty($uncreatedHosts[$nameserver['host']])) {
+                $this->createHost($nameserver['host'], $nameserver['ip'] ?? null);
+            }
+
+            $domain->addHost(new eppHost($nameserver['host']));
+        }
+
+        return $domain;
+    }
+
+    private function checkUncreatedHosts(array $nameservers): ?array
+    {
+        $hosts = [];
+        foreach ($nameservers as $nameserver) {
+            $hosts[] = $nameserver['host'];
+        }
+
+        $checkHost = [];
+        foreach ($hosts as $host) {
+            $checkHost[] = new eppHost($host);
+        }
+
+        $check = new eppCheckRequest($checkHost);
+        /** @var eppCheckResponse $response */
+        $response = $this->connection->request($check);
+
+        return $response->getCheckedHosts();
+    }
+}

--- a/src/CentralNic/Helper/CentralNicApi.php
+++ b/src/CentralNic/Helper/CentralNicApi.php
@@ -401,18 +401,6 @@ class CentralNicApi
         return $response->getDomainStatuses();
     }
 
-    public function getDomainEppCode(string $domainName): ?string
-    {
-        $domain = new eppDomain($domainName);
-
-        $info = new eppInfoDomainRequest($domain);
-
-        /** @var eppInfoDomainResponse $response */
-        $response = $this->connection->request($info);
-
-        return $response->getDomainAuthInfo();
-    }
-
     public function getHosts(string $domainName): ?array
     {
         $domain = new eppDomain($domainName);

--- a/src/CentralNic/Provider.php
+++ b/src/CentralNic/Provider.php
@@ -8,8 +8,6 @@ use Carbon\Carbon;
 use GuzzleHttp\Client;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use AfriCC\EPP\Frame\Response;
-use AfriCC\EPP\Frame\Response\MessageQueue;
 use Metaregistrar\EPP\eppException;
 use Metaregistrar\EPP\eppContactHandle;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
@@ -389,20 +387,6 @@ class Provider extends DomainNames implements ProviderInterface
     public function getEppCode(EppParams $params): EppCodeResult
     {
         throw $this->errorResult('Not implemented');
-
-        $domainName = Utils::getDomain(
-            Utils::normalizeSld($params->sld),
-            Utils::normalizeTld($params->tld)
-        );
-
-        try {
-            $eppCode = $this->api()->getDomainEppCode($domainName);
-            return EppCodeResult::create([
-                'epp_code' => $eppCode ?? "-",
-            ])->setMessage('EPP/Auth code obtained');
-        } catch (eppException $e) {
-            return $this->_eppExceptionHandler($e, $params->toArray());
-        }
     }
 
     public function updateIpsTag(IpsTagParams $params): ResultData

--- a/src/CentralNic/Provider.php
+++ b/src/CentralNic/Provider.php
@@ -1,0 +1,495 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\CentralNic;
+
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use AfriCC\EPP\Frame\Response;
+use AfriCC\EPP\Frame\Response\MessageQueue;
+use Metaregistrar\EPP\eppException;
+use Metaregistrar\EPP\eppContactHandle;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionBase\Provider\DataSet\ResultData;
+use Upmind\ProvisionProviders\DomainNames\Category as DomainNames;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppCodeResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppParams;
+use Upmind\ProvisionProviders\DomainNames\Data\IpsTagParams;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Data\RegisterDomainParams;
+use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\LockParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollResult;
+use Upmind\ProvisionProviders\DomainNames\Data\AutoRenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateDomainContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
+use Upmind\ProvisionProviders\DomainNames\CentralNic\Data\Configuration;
+use Upmind\ProvisionProviders\DomainNames\CentralNic\EppExtension\EppConnection;
+use Upmind\ProvisionProviders\DomainNames\CentralNic\Helper\CentralNicApi;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+
+/**
+ * Class Provider
+ *
+ * @package Upmind\ProvisionProviders\DomainNames\CentralNic
+ */
+class Provider extends DomainNames implements ProviderInterface
+{
+    /**
+     * @var Configuration
+     */
+    protected Configuration $configuration;
+
+    /**
+     * @var EppConnection|null
+     */
+    protected EppConnection $connection;
+
+    /**
+     * @var CentralNicApi
+     */
+    protected CentralNicApi $api;
+
+    private const MAX_CUSTOM_NAMESERVERS = 13;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function __destruct()
+    {
+        if (isset($this->connection) && $this->connection->isLoggedin()) {
+            $this->connection->logout();
+        }
+    }
+
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('CentralNic')
+            //TODO: fix desc, load logo
+            ->setDescription('Register, transfer, renew and manage CentralNic domains');
+        //->setLogoUrl('https://api.upmind.io/images/logos/provision/centralnic-logo@2x.png');
+    }
+
+    public function poll(PollParams $params): PollResult
+    {
+        $since = $params->after_date ? Carbon::parse($params->after_date) : null;
+
+        try {
+            $poll = $this->api()->poll(intval($params->limit), $since);
+            return PollResult::create($poll);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    public function domainAvailabilityCheck(DacParams $params): DacResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+        $domains = array_map(
+            fn($tld) => $sld . "." . Utils::normalizeTld($tld),
+            $params->tlds
+        );
+
+        try {
+            $dacDomains = $this->api()->checkMultipleDomains($domains);
+
+            return DacResult::create([
+                'domains' => $dacDomains,
+            ]);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    public function register(RegisterDomainParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        $checkResult = $this->api()->checkMultipleDomains([$domainName]);
+
+        if (count($checkResult) < 1) {
+            throw $this->errorResult('Empty domain availability check result');
+        }
+
+        if (!$checkResult[0]->can_register) {
+            throw $this->errorResult('This domain is not available to register');
+        }
+
+        $contacts = $this->getRegisterParams($params);
+
+        $nameServers = [];
+
+        for ($i = 1; $i <= self::MAX_CUSTOM_NAMESERVERS; $i++) {
+            if (Arr::has($params, 'nameservers.ns' . $i)) {
+                $nameServers[] = Arr::get($params, 'nameservers.ns' . $i);
+            }
+        }
+
+        try {
+            $this->api()->register(
+                $domainName,
+                intval($params->renew_years),
+                $contacts,
+                $nameServers,
+            );
+
+            return $this->_getInfo($domainName, sprintf('Domain %s was registered successfully!', $domainName));
+        } catch (eppException $e) {
+            return $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    private function getRegisterParams(RegisterDomainParams $params): array
+    {
+        if (Arr::has($params, 'registrant.id')) {
+            $registrantID = $params->registrant->id;
+
+            if (!$this->api()->getContactInfo($registrantID)) {
+                throw $this->errorResult("Invalid registrant ID provided!", $params);
+            }
+
+        } else {
+            if (!Arr::has($params, 'registrant.register')) {
+                throw $this->errorResult('Registrant contact data is required!');
+            }
+
+            $registrantID = $this->api()->createContact(
+                $params->registrant->register,
+            );
+        }
+
+        if (Arr::has($params, 'admin.id')) {
+            $adminID = $params->admin->id;
+
+            if (!$this->api()->getContactInfo($adminID)) {
+                throw $this->errorResult("Invalid registrant ID provided!", $params);
+            }
+
+        } else {
+            if (!Arr::has($params, 'admin.register')) {
+                throw $this->errorResult('Admin contact data is required!');
+            }
+
+            $adminID = $this->api()->createContact(
+                $params->admin->register,
+            );
+        }
+
+        if (Arr::has($params, 'tech.id')) {
+            $techID = $params->tech->id;
+
+            if (!$this->api()->getContactInfo($techID)) {
+                throw $this->errorResult("Invalid registrant ID provided!", $params);
+            }
+        } else {
+            if (!Arr::has($params, 'tech.register')) {
+                throw $this->errorResult('Tech contact data is required!');
+            }
+
+            $techID = $this->api()->createContact(
+                $params->tech->register,
+            );
+        }
+
+
+        if (Arr::has($params, 'billing.id')) {
+            $billingID = $params->billing->id;
+
+            if (!$this->api()->getContactInfo($billingID)) {
+                throw $this->errorResult("Invalid registrant ID provided!", $params);
+            }
+        } else {
+            if (!Arr::has($params, 'billing.register')) {
+                throw $this->errorResult('Billing contact data is required!');
+            }
+
+            $billingID = $this->api()->createContact(
+                $params->billing->register,
+            );
+        }
+
+        return [
+            eppContactHandle::CONTACT_TYPE_REGISTRANT => $registrantID,
+            eppContactHandle::CONTACT_TYPE_ADMIN => $adminID,
+            eppContactHandle::CONTACT_TYPE_TECH => $techID,
+            eppContactHandle::CONTACT_TYPE_BILLING => $billingID,
+        ];
+    }
+
+    public function transfer(TransferParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        $eppCode = $params->epp_code ?: null;
+
+        try {
+            return $this->_getInfo($domainName, 'Domain active in registrar account');
+        } catch (eppException $e) {
+
+        }
+
+        try {
+            $transferId = $this->api()->initiateTransfer($domainName, $eppCode, intval($params->renew_years));
+
+            throw $this->errorResult(sprintf('Transfer for %s domain successfully created!', $domainName), ['transfer_id' => $transferId]);
+
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    public function renew(RenewParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        $period = intval($params->renew_years);
+
+        try {
+            $this->api()->renew($domainName, $period);
+
+            return $this->_getInfo($domainName, sprintf('Renewal for %s domain was successful!', $domainName));
+        } catch (eppException $e) {
+            return $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    public function getInfo(DomainInfoParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        try {
+            return $this->_getInfo($domainName);
+        } catch (eppException $e) {
+            return $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    public function _getInfo(string $domain, $msg = 'Domain data obtained'): DomainResult
+    {
+        $domainInfo = $this->api()->getDomainInfo($domain);
+
+        return DomainResult::create($domainInfo, false)->setMessage($msg);
+    }
+
+    public function updateRegistrantContact(UpdateDomainContactParams $params): ContactResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        try {
+            $contact = $this->api()->updateRegistrantContact($domainName, $params->contact);
+
+            return ContactResult::create($contact);
+        } catch (eppException $e) {
+            return $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    public function updateNameservers(UpdateNameserversParams $params): NameserversResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+        $tld = Utils::normalizeTld($params->tld);
+
+        $domainName = Utils::getDomain($sld, $tld);
+
+        $nameServers = [];
+
+        for ($i = 1; $i <= self::MAX_CUSTOM_NAMESERVERS; $i++) {
+            if (Arr::has($params, 'ns' . $i)) {
+                $nameServers[] = Arr::get($params, 'ns' . $i);
+            }
+        }
+
+        try {
+
+            $this->api()->updateNameServers($domainName, $nameServers);
+
+            $hosts = $this->api()->getHosts($domainName);
+
+            $returnNameservers = [];
+            foreach ($hosts as $i => $ns) {
+                $returnNameservers['ns' . ($i + 1)] = $ns->getHostname();
+            }
+
+            return NameserversResult::create($returnNameservers)
+                ->setMessage(sprintf('Name servers for %s domain were updated!', $domainName));
+        } catch (eppException $e) {
+            return $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    public function setLock(LockParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        $lock = !!$params->lock;
+
+        try {
+            $currentLockStatuses = $this->api()->getRegistrarLockStatuses($domainName);
+            $lockedStatuses = $this->api()->getLockedStatuses();
+
+            $addStatuses = [];
+            $removeStatuses = [];
+
+            if ($lock) {
+                if (!$addStatuses = array_diff($lockedStatuses, $currentLockStatuses)) {
+                    return $this->_getInfo($domainName, sprintf('Domain %s already locked', $domainName));
+                }
+            } else {
+                if (!$removeStatuses = array_intersect($lockedStatuses, $currentLockStatuses)) {
+                    return $this->_getInfo($domainName, sprintf('Domain %s already unlocked', $domainName));
+                }
+            }
+
+            $this->api()->setRegistrarLock($domainName, $addStatuses, $removeStatuses);
+
+            return $this->_getInfo($domainName, sprintf("Lock %s!", $lock ? 'enabled' : 'disabled'));
+
+        } catch (eppException $e) {
+            return $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    public function setAutoRenew(AutoRenewParams $params): DomainResult
+    {
+        throw $this->errorResult('Not implemented');
+    }
+
+    public function getEppCode(EppParams $params): EppCodeResult
+    {
+        throw $this->errorResult('Not implemented');
+
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        try {
+            $eppCode = $this->api()->getDomainEppCode($domainName);
+            return EppCodeResult::create([
+                'epp_code' => $eppCode ?? "-",
+            ])->setMessage('EPP/Auth code obtained');
+        } catch (eppException $e) {
+            return $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    public function updateIpsTag(IpsTagParams $params): ResultData
+    {
+        throw $this->errorResult('Not implemented');
+    }
+
+    private function _eppExceptionHandler(eppException $exception, array $data = [], array $debug = []): void
+    {
+        if ($response = $exception->getResponse()) {
+            $debug['response_xml'] = $response->saveXML();
+        }
+
+        switch ($exception->getCode()) {
+            case 2001:
+                $errorMessage = 'Invalid request data';
+                break;
+            case 2201:
+                $errorMessage = 'Permission denied';
+                break;
+            default:
+                $errorMessage = $exception->getMessage();
+        }
+
+        throw $this->errorResult(sprintf('Registry Error: %s', $errorMessage), $data, $debug, $exception);
+    }
+
+    protected function connect(): EppConnection
+    {
+        try {
+            if (!isset($this->connection) || !$this->connection->isConnected() || !$this->connection->isLoggedin()) {
+                $connection = new EppConnection(!!$this->configuration->debug);
+                $connection->setPsrLogger($this->getLogger());
+
+                // Set connection data
+                $connection->setHostname($this->resolveAPIURL());
+                $connection->setPort(700);
+                $connection->setUsername($this->configuration->username);
+                $connection->setPassword($this->configuration->password);
+
+                $connection->login();
+
+                return $this->connection = $connection;
+            }
+
+            return $this->connection;
+
+        } catch (eppException $e) {
+            switch ($e->getCode()) {
+                case 2001:
+                    $errorMessage = 'Authentication error; check credentials';
+                    break;
+                case 2200:
+                    $errorMessage = 'Authentication error; check credentials and whitelisted IPs';
+                    break;
+                default:
+                    $errorMessage = 'Unexpected provider connection error';
+            }
+
+            throw $this->errorResult(trim(sprintf('%s %s', $e->getCode() ?: null, $errorMessage)), [], [], $e);
+        } catch (ErrorException $e) {
+            if (Str::containsAll($e->getMessage(), ['stream_socket_client()', 'SSL'])) {
+                // this usually means they've not whitelisted our IPs
+                $errorMessage = 'Connection error; check whitelisted IPs';
+            } else {
+                $errorMessage = 'Unexpected provider connection error';
+            }
+
+            throw $this->errorResult($errorMessage, [], [], $e);
+        }
+    }
+
+    private function api(): CentralNicApi
+    {
+        if (isset($this->api)) {
+            return $this->api;
+        }
+
+        $this->connect();
+
+        return $this->api ??= new CentralNicApi($this->connection, $this->configuration);
+    }
+
+    private function resolveAPIURL(): string
+    {
+        return $this->configuration->sandbox
+            ? 'ssl://epp-ote.centralnic.com'
+            : 'ssl://epp.centralnic.com';
+    }
+}

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -25,6 +25,7 @@ use Upmind\ProvisionProviders\DomainNames\Nira\Provider as Nira;
 use Upmind\ProvisionProviders\DomainNames\Ricta\Provider as Ricta;
 use Upmind\ProvisionProviders\DomainNames\UGRegistry\Provider as UGRegistry;
 use Upmind\ProvisionProviders\DomainNames\DomainNameApi\Provider as DomainNameApi;
+use Upmind\ProvisionProviders\DomainNames\CentralNic\Provider as CentralNic;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -52,5 +53,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('domain-names', 'ug-registry', UGRegistry::class);
         $this->bindProvider('domain-names', 'domain-name-api', DomainNameApi::class);
         $this->bindProvider('domain-names', 'namecheap', Namecheap::class);
+        $this->bindProvider('domain-names', 'centralnic', CentralNic::class);
     }
 }


### PR DESCRIPTION
The following operations are implemented for CentralNIC:

1. poll()
2. domainAvailabilityCheck()
3. register()
4. transfer()
5. renew()
6. getInfo()
7. updateRegistrantContact()
8. updateNameservers()
9. setLock()

The following operations aren't supported:

setAutoRenew() - the operation isn't supported by CentralNIC
getEppCode() - the operation isn't available via CentralNIC's EPP API, only via GUI