### PR TITLE
Add Auda implementation

### DIFF
--- a/src/Auda/Data/Configuration.php
+++ b/src/Auda/Data/Configuration.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Auda\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * Auda configuration.
+ *
+ * @property-read string $username
+ * @property-read string $password
+ * @property-read string|null $certificate
+ * @property-read bool|null $sandbox
+ * @property-read bool|null $debug Whether or not to enable debug logging
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'username' => ['required', 'string', 'min:3'],
+            'password' => ['required', 'string', 'min:6'],
+            'certificate' => ['nullable', 'certificate_pem'],
+            'sandbox' => ['nullable', 'boolean'],
+            'debug' => ['nullable', 'boolean'],
+        ]);
+    }
+}

--- a/src/Auda/Data/Configuration.php
+++ b/src/Auda/Data/Configuration.php
@@ -23,7 +23,7 @@ class Configuration extends DataSet
         return new Rules([
             'username' => ['required', 'string', 'min:3'],
             'password' => ['required', 'string', 'min:6'],
-            'certificate' => ['nullable', 'certificate_pem'],
+            'certificate' => ['required', 'certificate_pem'],
             'sandbox' => ['nullable', 'boolean'],
             'debug' => ['nullable', 'boolean'],
         ]);

--- a/src/Auda/EppExtension/EppConnection.php
+++ b/src/Auda/EppExtension/EppConnection.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Auda\EppExtension;
+
+use Metaregistrar\EPP\eppCreateDomainResponse;
+use Metaregistrar\EPP\eppConnection as BaseEppConnection;
+use Psr\Log\LoggerInterface;
+use Upmind\ProvisionProviders\DomainNames\Auda\EppExtension\Requests\EppCreateDomainRequest;
+
+/**
+ * Class EppConnection
+ * @package Upmind\ProvisionProviders\DomainNames\Auda\EppExtension
+ */
+class EppConnection extends BaseEppConnection
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected LoggerInterface $logger;
+
+    /**
+     * EppConnection constructor.
+     * @param bool $logging
+     * @param string|null $settingsFile
+     */
+    public function __construct(bool $logging = false, string $settingsFile = null)
+    {
+        // Call parent's constructor
+        parent::__construct($logging, $settingsFile);
+        parent::addCommandResponse(EppCreateDomainRequest::class, eppCreateDomainResponse::class);
+    }
+
+    /**
+     * Set a PSR-3 logger.
+     */
+    public function setPsrLogger(?LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+        if (isset($logger)) {
+            $this->logFile = '/dev/null';
+        }
+    }
+
+    /**
+     * Writes a log message to the log file or PSR-3 logger.
+     *
+     * @inheritdoc
+     */
+    public function writeLog($text, $action)
+    {
+        if ($this->logging && isset($this->logger)) {
+            $message = $text;
+            $message = $this->hideTextBetween($message, '<clID>', '</clID>');
+            // Hide password in the logging
+            $message = $this->hideTextBetween($message, '<pw>', '</pw>');
+            $message = $this->hideTextBetween($message, '<pw><![CDATA[', ']]></pw>');
+            // Hide new password in the logging
+            $message = $this->hideTextBetween($message, '<newPW>', '</newPW>');
+            $message = $this->hideTextBetween($message, '<newPW><![CDATA[', ']]></newPW>');
+            // Hide domain password in the logging
+            $message = $this->hideTextBetween($message, '<domain:pw>', '</domain:pw>');
+            $message = $this->hideTextBetween($message, '<domain:pw><![CDATA[', ']]></domain:pw>');
+            // Hide contact password in the logging
+            $message = $this->hideTextBetween($message, '<contact:pw>', '</contact:pw>');
+            $message = $this->hideTextBetween($message, '<contact:pw><![CDATA[', ']]></contact:pw>');
+
+            $this->logger->debug(sprintf("Auda [%s]:\n %s", $action, trim($message)));
+        }
+
+        parent::writeLog($text, $action);
+    }
+}

--- a/src/Auda/EppExtension/Requests/EppCreateDomainRequest.php
+++ b/src/Auda/EppExtension/Requests/EppCreateDomainRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Auda\EppExtension\Requests;
+
+use Metaregistrar\EPP\eppDomain;
+
+class EppCreateDomainRequest extends \Metaregistrar\EPP\eppCreateDomainRequest
+{
+    function __construct(eppDomain $domain)
+    {
+        parent::__construct($domain, false);
+    }
+
+    public function setRegistrantExt(string $name, string $eligibilityType = 'Other' , string $policyReason = '2') {
+        $create = $this->createElement('auext:create');
+        $this->setNamespace('xmlns:auext', 'urn:X-au:params:xml:ns:auext-1.3', $create);
+
+        $auProperties = $this->createElement('auext:auProperties');
+        $auProperties->appendChild($this->createElement('auext:registrantName', $name));
+
+        $auProperties->appendChild($this->createElement('auext:eligibilityType', $eligibilityType));
+        $auProperties->appendChild($this->createElement('auext:policyReason', $policyReason));
+
+        $create->appendChild($auProperties);
+
+        $this->getExtension()->appendChild($create);
+    }
+}

--- a/src/Auda/Helper/EppHelper.php
+++ b/src/Auda/Helper/EppHelper.php
@@ -1,0 +1,588 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Auda\Helper;
+
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Upmind\ProvisionBase\Helper;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\DataSet\SystemInfo;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacDomain;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainNotification;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Metaregistrar\EPP\eppCheckDomainRequest;
+use Metaregistrar\EPP\eppCheckDomainResponse;
+use Metaregistrar\EPP\eppCheckHostResponse;
+use Metaregistrar\EPP\eppCheckHostRequest;
+use Metaregistrar\EPP\eppCheckRequest;
+use Metaregistrar\EPP\eppPollResponse;
+use Metaregistrar\EPP\eppPollRequest;
+use Metaregistrar\EPP\eppContact;
+use Metaregistrar\EPP\eppContactHandle;
+use Metaregistrar\EPP\eppContactPostalInfo;
+use Metaregistrar\EPP\eppCreateContactRequest;
+use Metaregistrar\EPP\eppCreateContactResponse;
+use Metaregistrar\EPP\eppCreateDomainResponse;
+use Metaregistrar\EPP\eppCreateHostRequest;
+use Metaregistrar\EPP\eppCreateResponse;
+use Metaregistrar\EPP\eppDomain;
+use Metaregistrar\EPP\eppException;
+use Metaregistrar\EPP\eppHost;
+use Metaregistrar\EPP\eppInfoContactRequest;
+use Metaregistrar\EPP\eppInfoContactResponse;
+use Metaregistrar\EPP\eppInfoDomainRequest;
+use Metaregistrar\EPP\eppInfoDomainResponse;
+use Metaregistrar\EPP\eppInfoHostRequest;
+use Metaregistrar\EPP\eppInfoHostResponse;
+use Metaregistrar\EPP\eppRenewRequest;
+use Metaregistrar\EPP\eppRenewResponse;
+use Metaregistrar\EPP\eppTransferRequest;
+use Metaregistrar\EPP\eppTransferResponse;
+use Metaregistrar\EPP\eppUpdateContactRequest;
+use Metaregistrar\EPP\eppUpdateContactResponse;
+use Metaregistrar\EPP\eppUpdateDomainRequest;
+use Metaregistrar\EPP\eppUpdateDomainResponse;
+use Metaregistrar\EPP\eppUpdateResponse;
+use Metaregistrar\EPP\eppResponse;
+use Upmind\ProvisionProviders\DomainNames\Auda\EppExtension\Requests\EppCreateDomainRequest;
+use Upmind\ProvisionProviders\DomainNames\Auda\EppExtension\EppConnection;
+use Upmind\ProvisionProviders\DomainNames\Auda\Data\Configuration;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactData;
+
+/**
+ * Class EppHelper
+ *
+ * @package Upmind\ProvisionProviders\DomainNames\Auda\Helper
+ */
+class EppHelper
+{
+    protected EppConnection $connection;
+    protected Configuration $configuration;
+
+    protected array $lockedStatuses = [
+        'clientUpdateProhibited',
+    ];
+
+    public function __construct(EppConnection $connection, Configuration $configuration)
+    {
+        $this->connection = $connection;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @param string[] $domains
+     * @return array
+     */
+    public function checkMultipleDomains(array $domains): array
+    {
+        $check = new eppCheckDomainRequest($domains);
+
+        /** @var eppCheckDomainResponse */
+        $response = $this->connection->request($check);
+
+        $checks = $response->getCheckedDomains();
+
+        $result = [];
+
+        foreach ($checks as $check) {
+            $canRegister = (bool)$check['available'] == "true";
+            $canTransfer = !$canRegister;
+
+            if (!$canRegister && isset($check['reason']) && Str::contains($check['reason'], 'Invalid name syntax')) {
+                $canTransfer = false;
+            }
+
+            $result[] = DacDomain::create([
+                'domain' => $check['domainname'],
+                'description' => $check['reason'] ?? sprintf(
+                        'Domain is %s to register',
+                        $canRegister ? 'available' : 'not available',
+                    ),
+                'tld' => Utils::getTld($check['domainname']),
+                'can_register' => $canRegister,
+                'can_transfer' => $canTransfer,
+                'is_premium' => false,
+            ]);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param int $limit
+     * @param Carbon|null $since
+     * @return array
+     */
+    public function poll(int $limit, ?Carbon $since): array
+    {
+        $notifications = [];
+        $countRemaining = 0;
+
+        /**
+         * Start a timer because there may be 1000s of irrelevant messages and we should try and avoid a timeout.
+         */
+        $timeLimit = 60; // 60 seconds
+        $startTime = time();
+
+        while (count($notifications) < $limit && (time() - $startTime) < $timeLimit) {
+            // get oldest message from queue
+            /** @var eppPollResponse $pollResponse */
+            $pollResponse = $this->connection->request(new eppPollRequest(eppPollRequest::POLL_REQ, 0));
+
+            $countRemaining = $pollResponse->getMessageCount();
+
+            if ($countRemaining == 0) {
+                break;
+            }
+
+            $messageId = $pollResponse->getMessageId();
+            $type = $pollResponse->getMessageType();
+            $message = $pollResponse->getMessage() ?: 'Domain Notification';
+            $domain = $pollResponse->getDomainName();
+            $messageDateTime = Carbon::parse($pollResponse->getMessageDate());
+
+            $this->connection->request(new eppPollRequest(eppPollRequest::POLL_ACK, $messageId));
+
+            if ($type != eppPollResponse::TYPE_TRANSFER) {
+                // this message is irrelevant
+                continue;
+            }
+
+            if (isset($since) && $messageDateTime->lessThan($since)) {
+                // this message is too old
+                continue;
+            }
+
+            $notifications[] = DomainNotification::create()
+                ->setId($messageId)
+                ->setType(DomainNotification::TYPE_TRANSFER_IN)
+                ->setMessage($message)
+                ->setDomains([$domain])
+                ->setCreatedAt($messageDateTime)
+                ->setExtra(['xml' => $pollResponse->saveXML()]);
+        }
+
+        return [
+            'count_remaining' => $countRemaining,
+            'notifications' => $notifications,
+        ];
+    }
+
+    /**
+     * @param string $domainName
+     * @param int $period
+     * @param string[] $nameServers
+     * @param array $contacts
+     * @return array
+     */
+    public function register(
+        string $domainName,
+        int    $period,
+        array  $nameServers,
+        array  $contacts
+    ): array
+    {
+        $domain = new eppDomain($domainName, $contacts['registrant'], [
+            new eppContactHandle($contacts['tech'], eppContactHandle::CONTACT_TYPE_TECH),
+            new eppContactHandle($contacts['billing'], eppContactHandle::CONTACT_TYPE_BILLING),
+            new eppContactHandle($contacts['admin'], eppContactHandle::CONTACT_TYPE_ADMIN)
+        ]);
+
+        $domain->setRegistrant(new eppContactHandle($contacts['registrant']));
+
+        foreach ($nameServers as $nameserver) {
+            $domain->addHost(new eppHost($nameserver));
+        }
+
+        // Set Domain Period
+        $domain->setPeriod($period);
+        $domain->setPeriodUnit('y');
+        $domain->setAuthorisationCode(self::generateValidAuthCode());
+
+        // Create the domain
+        $create = new eppCreateDomainRequest($domain);
+
+        $organisationName = $this->getContactInfo($contacts['registrant'])->organisation;
+        $create->setRegistrantExt($organisationName);
+
+        /** @var eppCreateDomainResponse */
+        $response = $this->connection->request($create);
+
+        return [
+            'domain' => $response->getDomainName(),
+            'created_at' => Utils::formatDate($response->getDomainCreateDate()),
+            'expires_at' => Utils::formatDate($response->getDomainExpirationDate())
+        ];
+    }
+
+    private static function generateValidAuthCode(int $length = 16): string
+    {
+        return Helper::generateStrictPassword($length, true, true, true, '!@#$%^*_');
+    }
+
+    /**
+     * @param ContactParams $params
+     * @param string $type
+     * @return string
+     */
+    public function createContact(ContactParams $params, string $type): string
+    {
+        $telephone = null;
+        if ($params->phone) {
+            $telephone = Utils::internationalPhoneToEpp($params->phone);
+        }
+
+        $countryCode = null;
+        if ($params->country_code) {
+            $countryCode = Utils::normalizeCountryCode($params->country_code);
+        }
+
+        $postalInfo = new eppContactPostalInfo(
+            $params->name ?: $params->organisation,
+            $params->city,
+            $countryCode,
+            $params->organisation,
+            $params->address1,
+            $params->state,
+            $params->postcode,
+            eppContact::TYPE_LOC,
+        );
+
+        $contactInfo = new eppContact($postalInfo, $params->email, $telephone);
+
+        $contactInfo->setType($type);
+        $contactInfo->setPassword($params->password ?? self::generateValidAuthCode());
+
+        $contact = new eppCreateContactRequest($contactInfo);
+
+        /** @var eppCreateContactResponse $response */
+        $response = $this->connection->request($contact);
+
+        return $response->getContactId();
+    }
+
+    /**
+     * @param string $contactId
+     * @return ContactData
+     */
+    public function getContactInfo(string $contactId): ContactData
+    {
+        $request = new eppInfoContactRequest(new eppContactHandle($contactId), false);
+
+        $response = $this->connection->request($request);
+
+        return ContactData::create([
+            'id' => $contactId,
+            'name' => $response->getContactName(),
+            'email' => $response->getContactEmail(),
+            'phone' => $response->getContactVoice(),
+            'organisation' => $response->getContactCompanyname(),
+            'address1' => $response->getContactStreet(),
+            'city' => $response->getContactCity(),
+            'state' => $response->getContactProvince(),
+            'postcode' => $response->getContactZipcode(),
+            'country_code' => $response->getContactCountrycode(),
+        ]);
+    }
+
+    /**
+     * @param string $domainName
+     * @return array
+     */
+    public function getDomainInfo(string $domainName): array
+    {
+        $domain = new eppDomain($domainName);
+        $info = new eppInfoDomainRequest($domain);
+
+        /** @var eppInfoDomainResponse */
+        $response = $this->connection->request($info);
+
+        if ($response->getDomainClientId() !== $this->configuration->username) {
+            throw ProvisionFunctionError::create(sprintf('Domain %s does not belong to the user', $domainName));
+        }
+
+        $registrantId = $response->getDomainRegistrant();
+        $billingId = $response->getDomainContact(eppContactHandle::CONTACT_TYPE_BILLING);
+        $techId = $response->getDomainContact(eppContactHandle::CONTACT_TYPE_TECH);
+        $adminId = $response->getDomainContact(eppContactHandle::CONTACT_TYPE_ADMIN);
+
+        return [
+            'id' => $response->getDomainId(),
+            'domain' => $response->getDomainName(),
+            'statuses' => $response->getDomainStatuses() ?? [],
+            'locked' => boolval(array_intersect($this->lockedStatuses, $response->getDomainStatuses() ?? [])),
+            'registrant' => $registrantId ? $this->getContactInfo($registrantId) : null,
+            'billing' => $billingId ? $this->getContactInfo($billingId) : null,
+            'tech' => $techId ? $this->getContactInfo($techId) : null,
+            'admin' => $adminId ? $this->getContactInfo($adminId) : null,
+            'ns' => $this->parseNameServers($response->getDomainNameservers() ?? []),
+            'created_at' => Utils::formatDate($response->getDomainCreateDate()),
+            'updated_at' => Utils::formatDate($response->getDomainUpdateDate() ?: $response->getDomainCreateDate()),
+            'expires_at' => Utils::formatDate($response->getDomainExpirationDate()),
+        ];
+    }
+
+    /**
+     * @param array $nameServers
+     * @return array
+     */
+    private function parseNameServers(array $nameServers): array
+    {
+        $result = [];
+
+        if (count($nameServers) > 0) {
+            foreach ($nameServers as $i => $ns) {
+                $result['ns' . ($i + 1)] = [
+                    'host' => strtolower($ns->getHostName()),
+                ];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $domainName
+     * @return string[]
+     */
+    public function getRegistrarLockStatuses(string $domainName): array
+    {
+        $domain = new eppDomain($domainName);
+        $info = new eppInfoDomainRequest($domain);
+
+        /** @var eppInfoDomainResponse */
+        $response = $this->connection->request($info);
+
+        return $response->getDomainStatuses();
+    }
+
+    public function getLockedStatuses(): array
+    {
+        return $this->lockedStatuses;
+    }
+
+    /**
+     * @param string $domainName
+     * @param string[] $addStatuses
+     * @param string[] $removeStatuses
+     * @return void
+     */
+    public function setRegistrarLock(string $domainName, array $addStatuses, array $removeStatuses): void
+    {
+        if (count($addStatuses)) {
+            $add = new eppDomain($domainName);
+
+            foreach ($addStatuses as $status) {
+                $add->addStatus($status);
+            }
+        }
+
+        if (count($removeStatuses)) {
+            $del = new eppDomain($domainName);
+
+            foreach ($removeStatuses as $status) {
+                $del->addStatus($status);
+            }
+        }
+
+        $domain = new eppDomain($domainName);
+        $update = new eppUpdateDomainRequest($domain, $add ?? null, $del ?? null);
+
+        $this->connection->request($update);
+    }
+
+    /**
+     * @param string $domainName
+     * @return string
+     */
+    public function getDomainEppCode(string $domainName): string
+    {
+        $domain = new eppDomain($domainName);
+        $info = new eppInfoDomainRequest($domain);
+
+        /** @var eppInfoDomainResponse $response */
+        $response = $this->connection->request($info);
+
+        return $response->getDomainAuthInfo();
+    }
+
+    /**
+     * @param string $domainName
+     * @param int $period
+     * @return void
+     */
+    public function renew(string $domainName, int $period): void
+    {
+        $domainData = new eppDomain($domainName);
+
+        $domainData->setPeriod($period);
+        $domainData->setPeriodUnit('y');
+
+        $info = new eppInfoDomainRequest($domainData);
+
+        /** @var eppInfoDomainResponse $response */
+        $response = $this->connection->request($info);
+
+        $expiresAt = Utils::formatDate($response->getDomainExpirationDate(), 'Y-m-d');
+
+        $renewRequest = new eppRenewRequest($domainData, $expiresAt);
+
+        $this->connection->request($renewRequest);
+    }
+
+    /**
+     * @param string $domainName
+     * @param string[] $nameservers
+     * @return void
+     */
+    public function updateNameservers(string $domainName, array $nameservers): void
+    {
+        $attachedHosts = $this->getHosts($domainName);
+
+        if (array_diff($attachedHosts, $nameservers) == array_diff($nameservers, $attachedHosts)) {
+            return;
+        }
+
+        if ($attachedHosts) {
+            $removeInfo = new eppDomain($domainName);
+
+            foreach ($attachedHosts as $ns) {
+                if (in_array($ns, $nameservers)) {
+                    continue;
+                }
+
+                $removeInfo->addHost(new eppHost($ns));
+            }
+        }
+
+        $addInfo = new eppDomain($domainName);
+
+        foreach ($nameservers as $nameserver) {
+            if (!in_array($nameserver, $attachedHosts)) {
+                $addInfo->addHost(new eppHost($nameserver));
+            }
+        }
+
+        $update = new eppUpdateDomainRequest(
+            new eppDomain($domainName),
+            $addInfo,
+            $removeInfo ?? null,
+            $updateInfo ?? null,
+        );
+
+        $this->connection->request($update);
+    }
+
+    /**
+     * @param string $domainName
+     * @return string[]
+     */
+    public function getHosts(string $domainName): array
+    {
+        $domain = new eppDomain($domainName);
+        $info = new eppInfoDomainRequest($domain);
+
+        /** @var eppInfoDomainResponse */
+        $response = $this->connection->request($info);
+
+        $nameservers = $response->getDomainNameservers();
+
+        $attachedHosts = [];
+        if ($nameservers) {
+            foreach ($nameservers as $ns) {
+                $attachedHosts[] = $ns->getHostname();
+            }
+        }
+
+        return $attachedHosts;
+    }
+
+    /**
+     * @param string $domainName
+     * @param ContactParams $params
+     * @return ContactData
+     */
+    public function updateRegistrantContact(string $domainName, ContactParams $params): ContactData
+    {
+        $registrantId = $this->createContact($params, 'registrant');
+
+        $upd = new eppDomain($domainName);
+        $upd->setRegistrant(new eppContactHandle($registrantId));
+
+        $update = new eppUpdateDomainRequest(
+            new eppDomain($domainName),
+            null,
+            null,
+            $upd
+        );
+
+        $this->connection->request($update);
+
+        return $this->getContactInfo($registrantId);
+    }
+
+    /**
+     * @param string $domainName
+     * @param int $renewYears
+     * @param string|null $eppCode
+     * @param array $contacts
+     * @return eppTransferResponse
+     */
+    public function initiateTransfer(
+        string  $domainName,
+        int     $renewYears,
+        ?string $eppCode,
+        array   $contacts
+    ): eppTransferResponse
+    {
+        $contactHandle = [];
+
+        if ($contacts['tech']) {
+            $contactHandle[] = new eppContactHandle($contacts['tech'], eppContactHandle::CONTACT_TYPE_TECH);
+        }
+
+        if ($contacts['billing']) {
+            $contactHandle[] = new eppContactHandle($contacts['billing'], eppContactHandle::CONTACT_TYPE_BILLING);
+        }
+
+        if ($contacts['admin']) {
+            $contactHandle[] = new eppContactHandle($contacts['admin'], eppContactHandle::CONTACT_TYPE_ADMIN);
+        }
+
+        $domain = new eppDomain($domainName, $contacts['registrant'], $contactHandle);
+
+        // Set EPP Code
+        if ($eppCode != null) {
+            $domain->setAuthorisationCode($eppCode);
+        }
+
+        $domain->setPeriod($renewYears);
+        $domain->setPeriodUnit('y');
+
+        $transferRequest = new eppTransferRequest(eppTransferRequest::OPERATION_REQUEST, $domain);
+
+        /** @var eppTransferResponse */
+        return $this->connection->request($transferRequest);
+    }
+
+    /**
+     * @param string $domainName
+     * @return string
+     */
+    public function getTransferInfo(string $domainName): string
+    {
+        $domain = new eppDomain($domainName);
+
+        $transferRequest = new eppTransferRequest(eppTransferRequest::OPERATION_QUERY, $domain);
+
+        /** @var eppTransferResponse */
+        $response = $this->connection->request($transferRequest);
+
+        return (string)$response->getTransferStatus();
+    }
+}

--- a/src/Auda/Provider.php
+++ b/src/Auda/Provider.php
@@ -482,9 +482,7 @@ class Provider extends DomainNames implements ProviderInterface
                 $connection->setUsername($this->configuration->username);
                 $connection->setPassword($this->configuration->password);
 
-                $cert = $this->configuration->certificate
-                    ? $this->getCertificatePath($this->configuration->certificate)
-                    : __DIR__ . '/cert.pem';
+                $cert = $this->getCertificatePath($this->configuration->certificate);
 
                 $connection->enableCertification($cert, null);
 

--- a/src/Auda/Provider.php
+++ b/src/Auda/Provider.php
@@ -1,0 +1,553 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Auda;
+
+use Carbon\Carbon;
+use ErrorException;
+use GuzzleHttp\Client;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Metaregistrar\EPP\eppException;
+use Metaregistrar\EPP\eppContactHandle;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionBase\Provider\DataSet\ResultData;
+use Upmind\ProvisionProviders\DomainNames\Category as DomainNames;
+use Upmind\ProvisionProviders\DomainNames\Auda\Helper\EppHelper;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppCodeResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppParams;
+use Upmind\ProvisionProviders\DomainNames\Data\FinishTransferParams;
+use Upmind\ProvisionProviders\DomainNames\Data\InitiateTransferResult;
+use Upmind\ProvisionProviders\DomainNames\Data\IpsTagParams;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Data\RegisterDomainParams;
+use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\LockParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollResult;
+use Upmind\ProvisionProviders\DomainNames\Data\AutoRenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactData;
+use Upmind\ProvisionProviders\DomainNames\Data\Nameserver;
+use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateDomainContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
+use Upmind\ProvisionProviders\DomainNames\Auda\Data\Configuration;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Upmind\ProvisionProviders\DomainNames\Auda\EppExtension\EppConnection;
+
+/**
+ * Auda provider.
+ */
+class Provider extends DomainNames implements ProviderInterface
+{
+    protected Configuration $configuration;
+    protected EppConnection $connection;
+    protected EppHelper $epp;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function __destruct()
+    {
+        if (isset($this->connection) && $this->connection->isLoggedin()) {
+            $this->connection->logout();
+        }
+    }
+
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('Auda')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/auda-logo.png')
+            ->setDescription(
+                'Register, transfer, renew and manage Auda domains'
+            );
+    }
+
+    public function poll(PollParams $params): PollResult
+    {
+        $since = $params->after_date ? Carbon::parse($params->after_date) : null;
+
+        try {
+            $poll = $this->epp()->poll(intval($params->limit), $since);
+
+            return PollResult::create($poll);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    public function domainAvailabilityCheck(DacParams $params): DacResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+        $domains = array_map(
+            fn($tld) => $sld . "." . Utils::normalizeTld($tld),
+            $params->tlds
+        );
+
+        try {
+            $dacDomains = $this->epp()->checkMultipleDomains($domains);
+
+            return DacResult::create([
+                'domains' => $dacDomains,
+            ]);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    public function register(RegisterDomainParams $params): DomainResult
+    {
+
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        $checkResult = $this->epp()->checkMultipleDomains([$domainName]);
+
+        if (count($checkResult) < 1) {
+            throw $this->errorResult('Empty domain availability check result');
+        }
+
+        if (!$checkResult[0]->can_register) {
+            throw $this->errorResult('This domain is not available to register');
+        }
+
+        $contactParams = [
+            'registrant' => $params->registrant,
+            'admin' => $params->admin,
+            'tech' => $params->tech,
+            'billing' => $params->billing,
+        ];
+
+        try {
+            $contactsId = $this->getContactsId($contactParams);
+
+            $this->epp()->register(
+                $domainName,
+                intval($params->renew_years),
+                $params->nameservers->pluckHosts(),
+                $contactsId,
+            );
+
+            return $this->_getInfo($domainName, sprintf('Domain %s was registered successfully!', $domainName));
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    /**
+     * @return array<string,int>|string[]
+     */
+    private function getContactsId(array $params): array
+    {
+        if (Arr::has($params, 'billing.id')) {
+            $billingId = $params['billing']['id'];
+
+            if (!$this->epp()->getContactInfo($billingId)) {
+                throw $this->errorResult("Invalid billing ID provided!", $params);
+            }
+        } else if (Arr::has($params, 'billing.register')) {
+            $billingId = $this->epp()->createContact($params['billing']['register'], 'billing');
+        }
+
+        if (Arr::has($params, 'tech.id')) {
+            $techId = $params['tech']['id'];
+
+            if (!$this->epp()->getContactInfo($techId)) {
+                throw $this->errorResult("Invalid tech ID provided!", $params);
+            }
+        } else if (Arr::has($params, 'tech.register')) {
+            $techId = $this->epp()->createContact($params['tech']['register'], 'tech');
+        }
+
+        if (Arr::has($params, 'registrant.id')) {
+            $registrantId = $params['registrant']['id'];
+
+            if (!$this->epp()->getContactInfo($registrantId)) {
+                throw $this->errorResult("Invalid registrant ID provided!", $params);
+            }
+        } else if (Arr::has($params, 'registrant.register')) {
+            $registrantId = $this->epp()->createContact($params['registrant']['register'], 'registrant');
+        }
+
+        if (Arr::has($params, 'admin.id')) {
+            $adminId = $params['admin']['id'];
+
+            if (!$this->epp()->getContactInfo($adminId)) {
+                throw $this->errorResult("Invalid admin ID provided!", $params);
+            }
+        } else if (Arr::has($params, 'admin.register')) {
+            $adminId = $this->epp()->createContact($params['admin']['register'], 'admin');
+        }
+
+        return array(
+            'registrant' => $registrantId ?? null,
+            'admin' => $adminId ?? null,
+            'tech' => $techId ?? null,
+            'billing' => $billingId ?? null,
+        );
+    }
+
+    public function transfer(TransferParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        $eppCode = $params->epp_code ?: null;
+
+        try {
+            return $this->_getInfo($domainName, 'Domain active in registrar account');
+        } catch (\Throwable $e) {
+            // initiate transfer ...
+        }
+
+        $contactParams = [
+            'registrant' => $params->registrant,
+            'admin' => $params->admin,
+            'tech' => $params->tech,
+            'billing' => $params->billing,
+        ];
+
+        try {
+            $contactsId = $this->getContactsId($contactParams);
+
+            $transferId = $this->epp()->initiateTransfer(
+                $domainName,
+                intval($params->renew_years),
+                $eppCode,
+                $contactsId
+            );
+
+            throw $this->errorResult(sprintf('Transfer for %s domain successfully initiated!', $domainName), [
+                'transfer_id' => $transferId
+            ]);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    public function initiateTransfer(TransferParams $params): InitiateTransferResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        $eppCode = $params->epp_code ?: null;
+
+        try {
+            $domain = $this->_getInfo($domainName, '');
+
+            return InitiateTransferResult::create([
+                'domain' => $domainName,
+                'transfer_status' => 'complete',
+                'domain_info' => $domain,
+            ])->setMessage('Domain active in registrar account');
+        } catch (eppException $e) {
+            // initiate transfer ...
+        }
+
+        $contactParams = [
+            'registrant' => $params->registrant,
+            'admin' => $params->admin,
+            'tech' => $params->tech,
+            'billing' => $params->billing,
+        ];
+
+        try {
+            $contactsId = $this->getContactsId($contactParams);
+
+            $transferId = $this->epp()->initiateTransfer(
+                $domainName,
+                intval($params->renew_years),
+                $eppCode,
+                $contactsId
+            );
+
+            return InitiateTransferResult::create([
+                'domain' => $domainName,
+                'transfer_status' => 'in_progress',
+                'transfer_order_id' => $transferId
+            ])->setMessage(sprintf('Transfer for %s domain successfully created!', $domainName));
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    public function finishTransfer(FinishTransferParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        try {
+            return $this->_getInfo($domainName, 'Domain active in registrar account');
+        } catch (eppException $e) {
+        }
+
+        try {
+            $status = $this->epp()->getTransferInfo($domainName);
+
+            throw $this->errorResult(
+                sprintf('Transfer order status for %s: %s', $domainName, $status),
+                [],
+                $params
+            );
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    public function renew(RenewParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        $period = intval($params->renew_years);
+
+        try {
+            $this->epp()->renew($domainName, $period);
+
+            return $this->_getInfo($domainName, sprintf('Renewal for %s domain was successful!', $domainName));
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    public function getInfo(DomainInfoParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        try {
+            return $this->_getInfo($domainName);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    public function _getInfo(string $domain, $msg = 'Domain data obtained'): DomainResult
+    {
+        $domainInfo = $this->epp()->getDomainInfo($domain);
+
+        return DomainResult::create($domainInfo, false)->setMessage($msg);
+    }
+
+    public function updateRegistrantContact(UpdateDomainContactParams $params): ContactResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        try {
+            $contact = $this->epp()->updateRegistrantContact($domainName, $params->contact);
+
+            return ContactResult::create($contact);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    public function updateNameservers(UpdateNameserversParams $params): NameserversResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+        $tld = Utils::normalizeTld($params->tld);
+
+        $domainName = Utils::getDomain($sld, $tld);
+
+        try {
+            $this->epp()->updateNameservers($domainName, $params->pluckHosts());
+
+            $result = collect($params->pluckHosts())
+                ->mapWithKeys(fn($ns, $i) => ['ns' . ($i + 1) => ['host' => $ns]]);
+
+            return NameserversResult::create($result)
+                ->setMessage(sprintf('Name servers for %s domain were updated!', $domainName));
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    public function setLock(LockParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        $lock = !!$params->lock;
+
+        try {
+            $currentLockStatuses = $this->epp()->getRegistrarLockStatuses($domainName);
+            $lockedStatuses = $this->epp()->getLockedStatuses();
+
+            $addStatuses = [];
+            $removeStatuses = [];
+
+            if ($lock) {
+                if (!$addStatuses = array_diff($lockedStatuses, $currentLockStatuses)) {
+                    return $this->_getInfo($domainName, sprintf('Domain %s already locked', $domainName));
+                }
+            } else {
+                if (!$removeStatuses = array_intersect($lockedStatuses, $currentLockStatuses)) {
+                    return $this->_getInfo($domainName, sprintf('Domain %s already unlocked', $domainName));
+                }
+            }
+
+            $this->epp()->setRegistrarLock($domainName, $addStatuses, $removeStatuses);
+
+            return $this->_getInfo($domainName, sprintf("Lock %s!", $lock ? 'enabled' : 'disabled'));
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    public function setAutoRenew(AutoRenewParams $params): DomainResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    public function getEppCode(EppParams $params): EppCodeResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        try {
+            $eppCode = $this->epp()->getDomainEppCode($domainName);
+
+            return EppCodeResult::create([
+                'epp_code' => $eppCode,
+            ])->setMessage('EPP/Auth code obtained');
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    public function updateIpsTag(IpsTagParams $params): ResultData
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    private function _eppExceptionHandler(eppException $exception, array $data = [], array $debug = []): void
+    {
+        if ($response = $exception->getResponse()) {
+            $debug['response_xml'] = $response->saveXML();
+        }
+
+        switch ($exception->getCode()) {
+            case 2001:
+                $errorMessage = 'Invalid request data';
+                break;
+            case 2201:
+                $errorMessage = 'Permission denied';
+                break;
+            default:
+                $errorMessage = $exception->getMessage();
+        }
+
+        throw $this->errorResult(sprintf('Registry Error: %s', $errorMessage), $data, $debug, $exception);
+    }
+
+    protected function connect(): EppConnection
+    {
+        try {
+            if (!isset($this->connection) || !$this->connection->isConnected() || !$this->connection->isLoggedin()) {
+                $connection = new EppConnection(!!$this->configuration->debug);
+                $connection->setPsrLogger($this->getLogger());
+
+                // Set connection data
+                $connection->setHostname($this->resolveAPIURL());
+                $connection->setPort(700);
+                $connection->setUsername($this->configuration->username);
+                $connection->setPassword($this->configuration->password);
+
+                $cert = $this->configuration->certificate
+                    ? $this->getCertificatePath($this->configuration->certificate)
+                    : __DIR__ . '/cert.pem';
+
+                $connection->enableCertification($cert, null);
+
+                $connection->login();
+
+                return $this->connection = $connection;
+            }
+
+            return $this->connection;
+        } catch (eppException $e) {
+            switch ($e->getCode()) {
+                case 2200:
+                case 2001:
+                    $errorMessage = 'Authentication error; check credentials';
+                    break;
+                default:
+                    $errorMessage = 'Unexpected provider connection error';
+            }
+
+            throw $this->errorResult(trim(sprintf('%s %s', $e->getCode() ?: null, $errorMessage)), [], [], $e);
+        } catch (ErrorException $e) {
+            throw $this->errorResult('Unexpected provider connection error', [], [], $e);
+        }
+    }
+
+    /**
+     * Returns a filesystem path to use for the given certificate PEM, creating
+     * the file if necessary.
+     *
+     * @param string|null $certificate Certificate PEM
+     *
+     * @return string|null Filesystem path to the certificate
+     */
+    protected function getCertificatePath(?string $certificate): ?string
+    {
+        if (empty($certificate)) {
+            return null;
+        }
+
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . sha1($certificate);
+
+        if (!file_exists($path)) {
+            file_put_contents($path, $certificate, LOCK_EX);
+        }
+
+        return $path;
+    }
+
+    private function epp(): EppHelper
+    {
+        if (isset($this->epp)) {
+            return $this->epp;
+        }
+
+        $this->connect();
+
+        return $this->epp ??= new EppHelper($this->connection, $this->configuration);
+    }
+
+    private function resolveAPIURL(): string
+    {
+        return $this->configuration->sandbox
+            ? 'ssl://ote1.auda.ltd'
+            : 'ssl://auda.ltd';
+    }
+}

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -30,6 +30,7 @@ use Upmind\ProvisionProviders\DomainNames\GoDaddy\Provider as GoDaddy;
 use Upmind\ProvisionProviders\DomainNames\CentralNicReseller\Provider as CentralNicReseller;
 use Upmind\ProvisionProviders\DomainNames\RealtimeRegister\Provider as RealtimeRegister;
 use Upmind\ProvisionProviders\DomainNames\InternetBS\Provider as InternetBS;
+use Upmind\ProvisionProviders\DomainNames\Auda\Provider as Auda;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -62,5 +63,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('domain-names', 'centralnic-reseller', CentralNicReseller::class);
         $this->bindProvider('domain-names', 'realtime-register', RealtimeRegister::class);
         $this->bindProvider('domain-names', 'internetbs', InternetBS::class);
+        $this->bindProvider('domain-names', 'auda', Auda::class);
     }
 }


### PR DESCRIPTION
The following operations have been implemented for Auda:

poll()
domainAvailabilityCheck()
register()
transfer()
renew()
getInfo()
updateRegistrantContact()
updateNameservers()
getEppCode()
initiateTransfer()
finishTransfer()
setLock()

The following operations aren't supported by Auda:

updateIpsTag()
setAutoRenew()