### PR TITLE
Add InternetX implementation

### DIFF
--- a/src/InternetX/Data/Configuration.php
+++ b/src/InternetX/Data/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\InternetX\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * InternetX configuration.
+ *
+ * @property-read string $username API key
+ * @property-read string $password Password
+ * @property-read bool|null $sandbox Make API requests against the sandbox environment
+ * @property-read bool|null $debug Whether or not to log API requests and responses
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'username' => ['required', 'string', 'min:6'],
+            'password' => ['required', 'string', 'min:3'],
+            'sandbox' => ['nullable', 'boolean'],
+            'debug' => ['nullable', 'boolean'],
+        ]);
+    }
+}

--- a/src/InternetX/Helper/InternetXApi.php
+++ b/src/InternetX/Helper/InternetXApi.php
@@ -1,0 +1,515 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\InternetX\Helper;
+
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Arr;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\DataSet\SystemInfo;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactData;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacDomain;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainNotification;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Upmind\ProvisionProviders\DomainNames\InternetX\Data\Configuration;
+
+/**
+ * InternetX Domains API client.
+ */
+class InternetXApi
+{
+    /**
+     * Contact Types
+     */
+    public const CONTACT_TYPE_REGISTRANT = 'ownerc';
+    public const CONTACT_TYPE_TECH = 'techc';
+    public const CONTACT_TYPE_ADMIN = 'adminc';
+
+    protected Client $client;
+
+    protected Configuration $configuration;
+
+    public function __construct(Client $client, Configuration $configuration)
+    {
+        $this->client = $client;
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @return Promise<?array>
+     */
+    public function asyncRequest(
+        string $command,
+        ?array $query = null,
+        ?array $body = null,
+        string $method = 'POST'
+    ): Promise
+    {
+        $requestParams = [];
+        if ($query) {
+            $requestParams = ['query' => $query];
+        }
+
+        if ($body) {
+            $requestParams['json'] = $body;
+        }
+
+        return $this->client->requestAsync($method, "/v1{$command}", $requestParams)
+            ->then(function (Response $response) use ($command) {
+                $result = $response->getBody()->getContents();
+                $response->getBody()->close();
+
+                if ($result === '') {
+                    return null;
+                }
+
+                if ($command == '/poll') {
+                    return $this->parseResponseData($result);
+                }
+
+                return $this->parseResponseData($result)["data"][0];
+            });
+    }
+
+    public function makeRequest(
+        string $command,
+        ?array $query = null,
+        ?array $body = null,
+        string $method = 'GET'
+    ): ?array
+    {
+        return $this->asyncRequest($command, $query, $body, $method)->wait();
+    }
+
+    private function parseResponseData(string $result): array
+    {
+        $parsedResult = json_decode($result, true);
+
+        if (!$parsedResult) {
+            throw ProvisionFunctionError::create('Unknown Provider API Error')
+                ->withData([
+                    'response' => $result,
+                ]);
+        }
+
+        if ($error = $this->getResponseErrorMessage($parsedResult)) {
+            throw ProvisionFunctionError::create($error)
+                ->withData([
+                    'response' => $parsedResult,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+    protected function getResponseErrorMessage($responseData): ?string
+    {
+        $status = $responseData['status']['type'] ?: null;
+
+        if ($status == 'NOTIFY') {
+            return null;
+        }
+
+        if ($status != "SUCCESS") {
+            if (isset($responseData['messages'])) {
+                if (isset($responseData['messages'][0]['text'])) {
+                    $errorMessage = $responseData['messages'][0]['text'];
+                }
+            }
+
+            $errorMessage = sprintf('Provider API Error: %s', $errorMessage ?? 'Unknown Error');
+        }
+
+
+        return $errorMessage ?? null;
+    }
+
+    /**
+     * @param  string  $domainName
+     * @return array
+     */
+    public function getDomainInfo(string $domainName): array
+    {
+        $response = $this->makeRequest("/domain/{$domainName}");
+
+        return [
+            'id' => 'N/A',
+            'domain' => (string)$response['name'],
+            'statuses' => [$response['registrarStatus']],
+            'locked' => $response['registryStatus'] == 'LOCK',
+            'registrant' => isset($response['ownerc']["id"])
+                ? $this->getContactInfo($response['ownerc']["id"])
+                : null,
+            'billing' => null,
+            'tech' => isset($response['techc']["id"])
+                ? $this->getContactInfo($response['techc']["id"])
+                : null,
+            'admin' => isset($response['adminc']["id"])
+                ? $this->getContactInfo($response['adminc']["id"])
+                : null,
+            'ns' => NameserversResult::create($this->parseNameservers($response['nameServers'] ?? [])),
+            'created_at' => isset($response['created'])
+                ? Utils::formatDate((string)$response['created'])
+                : null,
+            'updated_at' => isset($response['updated'])
+                ? Utils::formatDate((string)$response['updated'])
+                : null,
+            'expires_at' => isset($response['payable'])
+                ? Utils::formatDate($response['payable'])
+                : null,
+        ];
+    }
+
+
+    /**
+     * @param  int  $id
+     * @return ContactData
+     */
+    public function getContactInfo(int $id): ContactData
+    {
+        $contact = $this->makeRequest("/contact/{$id}");
+        return ContactData::create([
+            'id' => $id,
+            'organisation' => isset($contact['organization']) ? (string)$contact['organization'] : null,
+            'name' => $contact['fname'] . ' ' . $contact['lname'],
+            'address1' => $contact['address'][0],
+            'city' => $contact['city'],
+            'state' => isset($contact['state']) ? (string)$contact['state'] : null,
+            'postcode' => $contact['pcode'],
+            'country_code' => Utils::normalizeCountryCode($contact['country']),
+            'email' => isset($contact['email']) ? (string)$contact['email'] : null,
+            'phone' => isset($contact['phone']) ? (string)$contact['phone'] : null,
+        ]);
+    }
+
+    /**
+     * @param ContactParams $contactParams
+     * @return int|null
+     */
+    public function createContact(ContactParams $contactParams): ?int
+    {
+        $body = $this->setContactParams($contactParams);
+
+        $response = $this->makeRequest("/contact", null, $body, "POST");
+
+        return $response['id'] ?? null;
+    }
+
+    /**
+     * @param array $nameservers
+     * @return array
+     */
+    private function parseNameservers(array $nameservers): array
+    {
+        $result = [];
+
+        if (count($nameservers) > 0) {
+            foreach ($nameservers as $i => $ns) {
+                $result['ns' . ($i + 1)] = ['host' => (string)$ns['name']];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $domainName
+     * @param int $period
+     * @param string[] $nameServers
+     * @param array $contacts
+     * @return void
+     */
+    public function register(string $domainName, int $period, array $contacts, array $nameServers): void
+    {
+        $ns = [];
+        foreach ($nameServers as $n) {
+            $ns[] = ["name" => $n];
+        }
+
+        $payable = Carbon::now()->add($period, 'year');
+        $body = [
+            'name' => $domainName,
+            'nameServers' => $ns,
+            'payable' => $payable->format("Y-m-d\TH:i:s.vO"),
+            'period' => [
+                "unit" => "YEAR",
+                "period" => $period,
+            ]
+        ];
+
+        foreach ($contacts as $type => $contactId) {
+            if ($contactId != null) {
+                $body[$type]['id'] = $contactId;
+            }
+        }
+
+        $this->makeRequest("/domain", null, $body, "POST");
+    }
+
+
+    /**
+     * @param ContactParams $contactParams
+     * @return array
+     */
+    private function setContactParams(ContactParams $contactParams): array
+    {
+        $nameParts = $this->getNameParts($contactParams->name ?? $contactParams->organisation);
+
+        return [
+            'address' => [
+                $contactParams->address1,
+            ],
+            'city' => $contactParams->city,
+            'country' => Utils::normalizeCountryCode($contactParams->country_code),
+            'pcode' => $contactParams->postcode,
+            'state' => $contactParams->state ?: '',
+            'organization' => $contactParams->organisation ?: '',
+            'fname' => $nameParts['firstName'],
+            'lname' => $nameParts['lastName'] ?: $nameParts['firstName'],
+            'email' => $contactParams->email,
+            'phone' => Utils::internationalPhoneToEpp($contactParams->phone),
+            "type" => $contactParams->type ?: "PERSON",
+        ];
+    }
+
+    /**
+     * @param string|null $name
+     * @return array
+     */
+    private function getNameParts(?string $name): array
+    {
+        $nameParts = explode(" ", $name);
+        $firstName = array_shift($nameParts);
+        $lastName = implode(" ", $nameParts);
+
+        return compact('firstName', 'lastName');
+    }
+
+    /**
+     * @param string $domainName
+     * @return string|null
+     */
+    public function getDomainEppCode(string $domainName): ?string
+    {
+        $response = $this->makeRequest("/domain/{$domainName}");
+        return $response['authinfo'] ?? null;
+    }
+
+    /**
+     * @param string $domainName
+     * @param bool $autoRenew
+     * @return void
+     */
+    public function setRenewalMode(string $domainName, bool $autoRenew)
+    {
+        $response = $this->makeRequest("/domain/{$domainName}");
+        $response['autoRenewStatus'] = $autoRenew ? "TRUE" : "FALSE";
+
+        $body = $response;
+        $this->makeRequest("/domain/{$domainName}", null, $body, "PUT");
+    }
+
+    /**
+     * @param string $domainName
+     * @return bool
+     */
+    public function getRegistrarLockStatus(string $domainName): bool
+    {
+        $response = $this->makeRequest("/domain/{$domainName}");
+        return $response['registryStatus'] == 'LOCK';
+    }
+
+    /**
+     * @param string $domainName
+     * @param bool $lock
+     * @return void
+     */
+    public function setRegistrarLock(string $domainName, bool $lock): void
+    {
+        $body = [
+            'registryStatus' => $lock ? 'LOCK' : 'ACTIVE',
+        ];
+
+        $this->makeRequest("/domain/{$domainName}/_statusUpdate", null, $body, "PUT");
+    }
+
+    /**
+     * @param string $domainName
+     * @param array $nameServers
+     * @return NameserversResult
+     */
+    public function updateNameservers(string $domainName, array $nameServers): NameserversResult
+    {
+        $ns = [];
+        foreach ($nameServers as $n) {
+            $ns[] = ["name" => $n];
+        }
+
+        $body = [
+            'nameServers' => $ns,
+        ];
+
+        $this->makeRequest("/domain/{$domainName}", null, $body, "PUT");
+
+        return $this->getDomainInfo($domainName)['ns'];
+    }
+
+    /**
+     * @param string $domainName
+     * @param ContactParams $contactParams
+     * @return ContactData
+     */
+    public function updateRegistrantContact(string $domainName, ContactParams $contactParams): ContactData
+    {
+        $contactData = $this->setContactParams($contactParams);
+        $body = [
+            self::CONTACT_TYPE_REGISTRANT => $contactData,
+            "confirmOwnerConsent" => true,
+        ];
+
+        $this->makeRequest("/domain/{$domainName}", null, $body, "PUT");
+
+        return $this->getDomainInfo($domainName)['registrant'];
+    }
+
+    /**
+     * @param string $domainName
+     * @param int $period
+     * @return void
+     */
+    public function renew(string $domainName, int $period): void
+    {
+        $response = $this->makeRequest("/domain/{$domainName}");
+        $payable = $response['payable'] ?? null;
+
+        $body = [
+            'payable' => $payable,
+            'period' => [
+                "unit" => "YEAR",
+                "period" => $period
+            ]
+        ];
+
+        $this->makeRequest("/domain/{$domainName}/_renew", null, $body, "PUT");
+    }
+
+    /**
+     * @param string $domainName
+     * @param string $eppCode
+     * @param array $contacts
+     * @param int $period
+     * @return string
+     */
+    public function initiateTransfer(string $domainName, string $eppCode, array $contacts, int $period): string
+    {
+        $payable = Carbon::now()->add($period, 'year');
+
+        $body = [
+            'name' => $domainName,
+            'authinfo' => $eppCode,
+            'payable' => $payable->format("Y-m-d\TH:i:s.vO"),
+            'period' => [
+                "unit" => "YEAR",
+                "period" => $period,
+            ]
+        ];
+
+        foreach ($contacts as $type => $contactId) {
+            if ($contactId != null) {
+                $body[$type]['id'] = $contactId;
+            }
+        }
+
+        $response = $this->makeRequest('/domain/_transfer', null, $body, 'POST');
+
+        return (string)$response['id'];
+    }
+
+    /**
+     * @param int $limit
+     * @param Carbon|null $since
+     * @return array
+     */
+    public function poll(int $limit, ?Carbon $since): array
+    {
+        $notifications = [];
+        $countRemaining = 0;
+
+        /**
+         * Start a timer because there may be 1000s of irrelevant messages and we should try and avoid a timeout.
+         */
+        $timeLimit = 60; // 60 seconds
+        $startTime = time();
+
+        while (count($notifications) < $limit && (time() - $startTime) < $timeLimit) {
+            $pollResponse = $this->makeRequest("/poll");
+
+            if($pollResponse['messages'][0]['text'] == "Polling is not activated."){
+                throw ProvisionFunctionError::create("Polling is not activated.")
+                    ->withData([
+                        'response' => $pollResponse,
+                    ]);
+            }
+
+            $countRemaining = $pollResponse['object']['summary'] ?? 0;
+
+            if ($countRemaining == 0) {
+                break;
+            }
+
+            $data = $pollResponse['data'][0];
+
+            $messageId = $data['id'];
+            $message = $pollResponse['messages'][0]['text'] ?: 'Domain Notification';
+            $domain = $data['name'];
+            $messageDateTime = isset($pollResponse['job']['created'])
+                ? Utils::formatDate((string)$pollResponse['job']['created'])
+                : null;
+
+            $this->makeRequest("/poll{$messageId}", null,null, 'PUT');
+
+            $type = "";
+            switch ($data['action']) {
+                case 'TRANSFER':
+                case 'CREATE':
+                    $type = DomainNotification::TYPE_TRANSFER_IN;
+                    break;
+                case 'DELETE':
+                    $type = DomainNotification::TYPE_DELETED;
+                    break;
+                case 'RENEW':
+                    $type = DomainNotification::TYPE_RENEWED;
+                    break;
+            }
+
+            if ($type == "") {
+                continue;
+            }
+
+            if (isset($since) && $messageDateTime->lessThan($since)) {
+                // this message is too old
+                continue;
+            }
+
+            $notifications[] = DomainNotification::create()
+                ->setId($messageId)
+                ->setType($type)
+                ->setMessage($message)
+                ->setDomains([$domain])
+                ->setCreatedAt($messageDateTime)
+                ->setExtra(['response' => json_encode($data)]);
+        }
+
+        return [
+            'count_remaining' => $countRemaining,
+            'notifications' => $notifications,
+        ];
+    }
+}

--- a/src/InternetX/Provider.php
+++ b/src/InternetX/Provider.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\InternetX;
+
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Throwable;
+use GuzzleHttp\Exception\RequestException;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionBase\Provider\DataSet\ResultData;
+use Upmind\ProvisionProviders\DomainNames\Category as DomainNames;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppCodeResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppParams;
+use Upmind\ProvisionProviders\DomainNames\Data\IpsTagParams;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Data\RegisterDomainParams;
+use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\LockParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollResult;
+use Upmind\ProvisionProviders\DomainNames\Data\AutoRenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateDomainContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
+use Upmind\ProvisionProviders\DomainNames\InternetX\Data\Configuration;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Upmind\ProvisionProviders\DomainNames\InternetX\Helper\InternetXApi;
+
+/**
+ * InternetX provider.
+ */
+class Provider extends DomainNames implements ProviderInterface
+{
+    protected Configuration $configuration;
+    /**
+     * @var InternetXApi
+     */
+    protected InternetXApi $api;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('InternetX')
+            ->setDescription('Register, transfer, and manage InternetX domain names')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/internetx-logo@2x.png');
+    }
+
+    public function poll(PollParams $params): PollResult
+    {
+        $since = $params->after_date ? Carbon::parse($params->after_date) : null;
+
+        try {
+            $poll = $this->api()->poll(intval($params->limit), $since);
+            return PollResult::create($poll);
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function domainAvailabilityCheck(DacParams $params): DacResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    public function register(RegisterDomainParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        $this->checkRegisterParams($params);
+
+        $contacts = [
+            'registrant' => $params->registrant,
+            'admin' => $params->admin,
+            'tech' => $params->tech,
+        ];
+
+        try {
+            $contactsId = $this->getContactsId($contacts);
+
+            $this->api()->register(
+                $domainName,
+                intval($params->renew_years),
+                $contactsId,
+                $params->nameservers->pluckHosts(),
+            );
+
+            throw $this->errorResult("Domain registration was started successfully.", $params);
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    /**
+     * @return array<string,int>|string[]
+     */
+    private function getContactsId(array $params): array
+    {
+        if (Arr::has($params, 'tech.id')) {
+            $techId = $params['tech']['id'];
+
+            if (!$this->api()->getContactInfo((int)$techId)) {
+                throw $this->errorResult("Invalid tech ID provided!", $params);
+            }
+        } else if (Arr::has($params, 'tech.register')) {
+            $techId = $this->api()->createContact($params['tech']['register']);
+        }
+
+        if (Arr::has($params, 'registrant.id')) {
+            $registrantId = $params['registrant']['id'];
+
+            if (!$this->api()->getContactInfo((int)$registrantId)) {
+                throw $this->errorResult("Invalid registrant ID provided!", $params);
+            }
+        } else if (Arr::has($params, 'registrant.register')) {
+            $registrantId = $this->api()->createContact($params['registrant']['register']);
+        }
+
+        if (Arr::has($params, 'admin.id')) {
+            $adminId = $params['admin']['id'];
+
+            if (!$this->api()->getContactInfo((int)$adminId)) {
+                throw $this->errorResult("Invalid admin ID provided!", $params);
+            }
+        } else if (Arr::has($params, 'admin.register')) {
+            $adminId = $this->api()->createContact($params['admin']['register']);
+        }
+
+        return array(
+            InternetXApi::CONTACT_TYPE_REGISTRANT => $registrantId ?? null,
+            InternetXApi::CONTACT_TYPE_ADMIN => $adminId ?? null,
+            InternetXApi::CONTACT_TYPE_TECH => $techId ?? null,
+        );
+    }
+
+    private function checkRegisterParams(RegisterDomainParams $params): void
+    {
+        if (!Arr::has($params, 'registrant.register')) {
+            throw $this->errorResult('Registrant contact data is required!');
+        }
+
+        if (!Arr::has($params, 'tech.register')) {
+            throw $this->errorResult('Tech contact data is required!');
+        }
+
+        if (!Arr::has($params, 'admin.register')) {
+            throw $this->errorResult('Admin contact data is required!');
+        }
+    }
+
+    public function transfer(TransferParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        $eppCode = $params->epp_code ?: '0000';
+
+        try {
+            return $this->_getInfo($domainName, 'Domain active in registrar account');
+        } catch (Throwable $e) {
+            // domain not active - continue below
+        }
+
+        $contacts = [
+            'registrant' => $params->registrant,
+            'admin' => $params->admin,
+            'tech' => $params->tech,
+        ];
+
+        try {
+            $contactsId = $this->getContactsId($contacts);
+
+            $transacId = $this->api()->initiateTransfer(
+                $domainName,
+                $eppCode,
+                $contactsId,
+                intval($params->renew_years),
+            );
+
+            throw $this->errorResult(sprintf('Transfer for %s domain successfully created!', $domainName), [
+                'transaction_id' => $transacId
+            ]);
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function renew(RenewParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $this->api()->renew($domainName, intval($params->renew_years));
+            return $this->_getInfo($domainName, sprintf('Renewal for %s domain was successful!', $domainName));
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function getInfo(DomainInfoParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            return $this->_getInfo($domainName, 'Domain data obtained');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    private function _getInfo(string $domainName, string $message): DomainResult
+    {
+        $domainInfo = $this->api()->getDomainInfo($domainName);
+
+        return DomainResult::create($domainInfo)->setMessage($message);
+    }
+
+    public function updateRegistrantContact(UpdateDomainContactParams $params): ContactResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $contact = $this->api()->updateRegistrantContact($domainName, $params->contact);
+
+            return ContactResult::create($contact);
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function updateNameservers(UpdateNameserversParams $params): NameserversResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $result = $this->api()->updateNameservers(
+                $domainName,
+                $params->pluckHosts(),
+            );
+
+            return $result
+                ->setMessage(sprintf('Name servers for %s domain were updated!', $domainName));
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function setLock(LockParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+        $lock = !!$params->lock;
+
+        try {
+            $currentLockStatus = $this->api()->getRegistrarLockStatus($domainName);
+            if (!$lock && !$currentLockStatus) {
+                return $this->_getInfo($domainName, sprintf('Domain %s already unlocked', $domainName));
+            }
+
+            if ($lock && $currentLockStatus) {
+                return $this->_getInfo($domainName, sprintf('Domain %s already locked', $domainName));
+            }
+
+            $this->api()->setRegistrarLock($domainName, $lock);
+
+            return $this->_getInfo($domainName, sprintf("Lock %s!", $lock ? 'enabled' : 'disabled'));
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function setAutoRenew(AutoRenewParams $params): DomainResult
+    {
+        throw $this->errorResult('Operation not supported');
+
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        $autoRenew = !!$params->auto_renew;
+
+        try {
+            $this->api()->setRenewalMode($domainName, $autoRenew);
+            return $this->_getInfo($domainName, 'Auto-renew mode updated');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function getEppCode(EppParams $params): EppCodeResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $eppCode = $this->api()->getDomainEppCode($domainName);
+
+            if (!$eppCode) {
+                return $this->errorResult('Unable to obtain EPP code for this domain!');
+            }
+
+            return EppCodeResult::create([
+                'epp_code' => $eppCode,
+            ])->setMessage('EPP/Auth code obtained');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function updateIpsTag(IpsTagParams $params): ResultData
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @throws Throwable
+     */
+    protected function handleException(Throwable $e): void
+    {
+        if ($e instanceof RequestException) {
+            if ($e->hasResponse()) {
+                $response = $e->getResponse();
+
+                $responseBody = $response->getBody()->__toString();
+                $responseData = json_decode($responseBody, true);
+
+
+                $errorMessage = $responseData['messages'][0]['text'] ?? null;
+
+                throw $this->errorResult(
+                    sprintf('Provider API Error: %s', $errorMessage),
+                    ['response_data' => $responseData],
+                    [],
+                    $e
+                );
+            }
+        }
+        throw $e;
+    }
+
+    protected function api(): InternetXApi
+    {
+        if (isset($this->api)) {
+            return $this->api;
+        }
+
+        $credentials = base64_encode("{$this->configuration->username}:{$this->configuration->password}");
+
+        $client = new Client([
+            'base_uri' => $this->resolveAPIURL(),
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'User-Agent' => 'Upmind/ProvisionProviders/DomainNames/InternetXApi',
+                'Authorization' => ['Basic ' . $credentials],
+                'X-Domainrobot-Context' => $this->resolveAPIContext(),
+            ],
+            'connect_timeout' => 10,
+            'timeout' => 60,
+            'verify' => !$this->configuration->sandbox,
+            'handler' => $this->getGuzzleHandlerStack(boolval($this->configuration->debug)),
+        ]);
+
+        return $this->api = new InternetXApi($client, $this->configuration);
+    }
+
+    public function resolveAPIURL(): string
+    {
+        return $this->configuration->sandbox
+            ? 'https://api.demo.autodns.com'
+            : 'https://api.autodns.com';
+    }
+
+    public function resolveAPIContext(): int
+    {
+        return $this->configuration->sandbox
+            ? 1
+            : 4;
+    }
+}

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -31,6 +31,7 @@ use Upmind\ProvisionProviders\DomainNames\CentralNicReseller\Provider as Central
 use Upmind\ProvisionProviders\DomainNames\RealtimeRegister\Provider as RealtimeRegister;
 use Upmind\ProvisionProviders\DomainNames\InternetBS\Provider as InternetBS;
 use Upmind\ProvisionProviders\DomainNames\EuroDNS\Provider as EuroDNS;
+use Upmind\ProvisionProviders\DomainNames\InternetX\Provider as InternetX;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -65,5 +66,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('domain-names', 'internetbs', InternetBS::class);
         $this->bindProvider('domain-names', 'hrs', HRS\Provider::class);
         $this->bindProvider('domain-names', 'eurodns', EuroDNS::class);
+        $this->bindProvider('domain-names', 'internetx', InternetX::class);
     }
 }


### PR DESCRIPTION
The following operations are implemented for InternetX:

poll() - not supported in sandbox mode, couldn't test the function
register()
transfer() 
renew()
getInfo()
updateRegistrantContact()
getEppCode()
updateNameservers();
setLock()

The following operations aren't supported by InternetX:

domainAvailabilityCheck()
setAutoRenew()
updateIpsTag()