### PR TITLE
Implement SynergyWholesale

### DIFF
--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -33,6 +33,7 @@ use Upmind\ProvisionProviders\DomainNames\InternetBS\Provider as InternetBS;
 use Upmind\ProvisionProviders\DomainNames\EuroDNS\Provider as EuroDNS;
 use Upmind\ProvisionProviders\DomainNames\InternetX\Provider as InternetX;
 use Upmind\ProvisionProviders\DomainNames\EURID\Provider as EURID;
+use Upmind\ProvisionProviders\DomainNames\SynergyWholesale\Provider as SynergyWholesale;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -69,5 +70,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('domain-names', 'eurodns', EuroDNS::class);
         $this->bindProvider('domain-names', 'internetx', InternetX::class);
         $this->bindProvider('domain-names', 'eurid', EURID::class);
+        $this->bindProvider('domain-names', 'synergy-wholesale', SynergyWholesale::class);
     }
 }

--- a/src/SynergyWholesale/Data/Configuration.php
+++ b/src/SynergyWholesale/Data/Configuration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\SynergyWholesale\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * SynergyWholesale configuration
+ *
+ * @property-read string $apiKey apiKey
+ * @property-read string $resellerID resellerID
+ * @property-read bool|null $sandbox Use OTE
+ * @property-read bool|null $debug Enable debug logging
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'apiKey' => ['required', 'string'],
+            'resellerID' => ['required', 'string'],
+            'sandbox' => ['boolean'],
+            'debug' => ['boolean'],
+        ]);
+    }
+}

--- a/src/SynergyWholesale/Helper/SynergyWholesaleApi.php
+++ b/src/SynergyWholesale/Helper/SynergyWholesaleApi.php
@@ -1,0 +1,418 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\SynergyWholesale\Helper;
+
+use Carbon\Carbon;
+use SoapClient;
+use Illuminate\Support\Arr;
+use Throwable;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\DataSet\SystemInfo;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactData;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacDomain;
+use Upmind\ProvisionProviders\DomainNames\Data\Nameserver;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Upmind\ProvisionProviders\DomainNames\SynergyWholesale\Data\Configuration;
+
+/**
+ * SynergyWholesale Domains API client.
+ */
+class SynergyWholesaleApi
+{
+    /**
+     * Contact Types
+     */
+    public const CONTACT_TYPE_REGISTRANT = 'registrant';
+    public const CONTACT_TYPE_TECH = 'technical';
+    public const CONTACT_TYPE_ADMIN = 'admin';
+    public const CONTACT_TYPE_BILLING = 'billing';
+
+    protected SoapClient $client;
+
+    protected Configuration $configuration;
+
+    public function __construct(SoapClient $client, Configuration $configuration)
+    {
+        $this->client = $client;
+        $this->configuration = $configuration;
+    }
+
+
+    public function makeRequest(string $command, ?array $params = null): ?array
+    {
+        if ($params) {
+            $requestParams = $params;
+        }
+
+        $requestParams['apiKey'] = $this->configuration->apiKey;
+        $requestParams['resellerID'] = $this->configuration->resellerID;
+
+        $response = $this->client->__soapCall($command, array($requestParams));
+
+        return $this->parseResponseData($response);
+    }
+
+
+    private function parseResponseData($result)
+    {
+        $parsedResult = json_decode(json_encode($result), true);
+
+        if (!$parsedResult) {
+            throw ProvisionFunctionError::create('Unknown Provider API Error')
+                ->withData([
+                    'response' => $parsedResult,
+                ]);
+        }
+
+        if ($error = $this->getResponseErrorMessage($parsedResult)) {
+            throw ProvisionFunctionError::create($error)
+                ->withData([
+                    'response' => $parsedResult,
+                ]);
+        }
+
+        return $parsedResult;
+    }
+
+
+    private function getResponseErrorMessage($responseData)
+    {
+        if ($responseData['status'] != "OK") {
+            $errorMessage = 'Unknown error';
+            if (isset($responseData['errorMessage'])) {
+                $errorMessage = $responseData['errorMessage'];
+            }
+        }
+
+        return $errorMessage ?? null;
+    }
+
+
+    public function getDomainInfo(string $domainName): array
+    {
+        $command = 'bulkDomainInfo';
+        $params = [
+            'domainList' => [$domainName],
+        ];
+        $response = $this->makeRequest($command, $params)["domainList"][0];
+
+        return [
+            'id' => $response['domainRoid'],
+            'domain' => (string)$response['domainName'],
+            'statuses' => [$response['domain_status']],
+            'locked' => $response['domain_status'] == 'clientTransferProhibited',
+            'registrant' => isset($response['contacts']['registrant'])
+                ? $this->parseContact($response['contacts']['registrant'])
+                : null,
+            'billing' => isset($response['contacts']['billing'])
+                ? $this->parseContact($response['contacts']['billing'])
+                : null,
+            'tech' => isset($response['contacts']['tech'])
+                ? $this->parseContact($response['contacts']['tech'])
+                : null,
+            'admin' => isset($response['contacts']['admin'])
+                ? $this->parseContact($response['contacts']['admin'])
+                : null,
+            'ns' => NameserversResult::create($this->parseNameservers($response['nameServers'])),
+            'created_at' => Utils::formatDate((string)$response['createdDate']),
+            'updated_at' => null,
+            'expires_at' => isset($response['domain_expiry']) ? Utils::formatDate($response['domain_expiry']) : null,
+        ];
+    }
+
+
+    private function parseNameservers(array $nameservers): array
+    {
+        $result = [];
+        $i = 1;
+
+        foreach ($nameservers as $ns) {
+            $result['ns' . $i] = ['host' => (string)$ns];
+            $i++;
+        }
+
+        return $result;
+    }
+
+
+    public function checkMultipleDomains(array $domains)
+    {
+        $command = 'bulkCheckDomain';
+        $params = [
+            'domainList' => $domains,
+        ];
+
+        $response = $this->makeRequest($command, $params);
+
+        $dacDomains = [];
+
+        foreach ($response['domainList'] ?? [] as $result) {
+            $available = $result['available'] == 1;
+
+            $dacDomains[] = DacDomain::create([
+                'domain' => $result['domain'],
+                'description' => sprintf(
+                    'Domain is %s to register',
+                    $available ? 'available' : 'not available'
+                ),
+                'tld' => Utils::getTld($result['domain']),
+                'can_register' => $available,
+                'can_transfer' => !$available,
+                'is_premium' => isset($result["premium"]) ?: 0,
+            ]);
+        }
+
+        return $dacDomains;
+    }
+
+
+    public function renew(string $domainName, int $period)
+    {
+        $command = 'renewDomain';
+
+        $params = [
+            'domainName' => $domainName,
+            'years' => $period
+        ];
+
+        $this->makeRequest($command, $params);
+    }
+
+
+    /**
+     * @param string[] $nameservers
+     */
+    public function updateNameservers(string $domainName, array $nameservers): array
+    {
+        $command = 'updateNameServers';
+
+        $params = [
+            'domainName' => $domainName,
+            'nameServers' => $nameservers
+        ];
+
+        $this->makeRequest($command, $params);
+
+        $command = 'domainInfo';
+        $params = [
+            'domainName' => $domainName,
+        ];
+        $response = $this->makeRequest($command, $params);
+
+        return $this->parseNameservers($response['nameServers']);
+    }
+
+
+    public function setRenewalMode(string $domainName, bool $autoRenew)
+    {
+        if ($autoRenew) {
+            $command = 'enableAutoRenewal';
+        } else {
+            $command = 'disableAutoRenewal';
+        }
+
+        $params = [
+            'domainName' => $domainName,
+        ];
+
+        $this->makeRequest($command, $params);
+    }
+
+
+    public function getRegistrarLockStatus(string $domainName): bool
+    {
+        $command = 'domainInfo';
+        $params = [
+            'domainName' => $domainName,
+        ];
+        $response = $this->makeRequest($command, $params);
+
+        return $response['domain_status'] == 'clientTransferProhibited';
+    }
+
+
+    public function setRegistrarLock(string $domainName, bool $lock)
+    {
+        if ($lock) {
+            $command = 'lockDomain';
+        } else {
+            $command = 'unlockDomain';
+        }
+
+        $params = [
+            'domainName' => $domainName,
+        ];
+
+        $this->makeRequest($command, $params);
+    }
+
+
+    public function getDomainEppCode(string $domainName)
+    {
+        $command = 'domainInfo';
+        $params = [
+            'domainName' => $domainName,
+        ];
+        $response = $this->makeRequest($command, $params);
+        return $response['domainPassword'];
+    }
+
+
+    public function register(string $domainName, int $years, array $contacts, array $nameServers)
+    {
+        $command = 'domainRegister';
+
+        $params = [
+            'domainName' => $domainName,
+            'years' => $years,
+            'nameServers' => $nameServers,
+            'idProtect' => ''
+        ];
+
+        foreach ($contacts as $type => $contact) {
+            if ($contact) {
+                $contactParams = $this->setContactParams($contact, $type);
+                $params = array_merge($params, $contactParams);
+            }
+        }
+
+        $this->makeRequest($command, $params);
+    }
+
+
+    private function setContactParams(ContactParams $contactParams, string $type): array
+    {
+        $nameParts = $this->getNameParts($contactParams->name ?? $contactParams->organisation);
+
+        return [
+            "{$type}_firstname" => $nameParts['firstName'],
+            "{$type}_lastname" => $nameParts['lastName'] ?: $nameParts['firstName'],
+            "{$type}_organisation" => $contactParams->organisation ?: '',
+            "{$type}_address" => [$contactParams->address1],
+            "{$type}_suburb" => $contactParams->city,
+            "{$type}_state" => $contactParams->state ?: $contactParams->city,
+            "{$type}_country" => Utils::normalizeCountryCode($contactParams->country_code),
+            "{$type}_postcode" => $contactParams->postcode,
+            "{$type}_phone" => Utils::internationalPhoneToEpp($contactParams->phone),
+            "{$type}_email" => $contactParams->email,
+            "{$type}_fax" => '',
+        ];
+    }
+
+
+    private function setContactData(ContactData $contactData, string $type): array
+    {
+        $nameParts = $this->getNameParts($contactData->name ?? $contactData->organisation);
+
+        return [
+            "{$type}_firstname" => $nameParts['firstName'],
+            "{$type}_lastname" => $nameParts['lastName'] ?: $nameParts['firstName'],
+            "{$type}_organisation" => $contactData->organisation ?: '',
+            "{$type}_address" => [$contactData->address1],
+            "{$type}_suburb" => $contactData->city,
+            "{$type}_state" => $contactData->state ?: $contactData->city,
+            "{$type}_country" => Utils::normalizeCountryCode($contactData->country_code),
+            "{$type}_postcode" => $contactData->postcode,
+            "{$type}_phone" => Utils::internationalPhoneToEpp($contactData->phone),
+            "{$type}_email" => $contactData->email,
+            "{$type}_fax" => '',
+        ];
+    }
+
+
+    /**
+     * @param string|null $name
+     *
+     * @return array
+     */
+    private function getNameParts(?string $name): array
+    {
+        $nameParts = explode(" ", $name);
+        $firstName = array_shift($nameParts);
+        $lastName = implode(" ", $nameParts);
+
+        return compact('firstName', 'lastName');
+    }
+
+
+    public function updateRegistrantContact(string $domainName, ContactParams $registrantParams): ContactData
+    {
+        $command = 'updateContact';
+
+        $params = [
+            'domainName' => $domainName,
+            "appPurpose" => "",
+            "nexusCategory" => "",
+        ];
+
+        $info = $this->getDomainInfo($domainName);
+
+
+        $contacts = [
+            self::CONTACT_TYPE_ADMIN => $info['admin'],
+            self::CONTACT_TYPE_TECH => $info['tech'],
+            self::CONTACT_TYPE_BILLING => $info['billing'],
+        ];
+
+        foreach ($contacts as $type => $contact) {
+            if ($contact) {
+                $contactParams = $this->setContactData($contact, $type);
+                $params = array_merge($params, $contactParams);
+            }
+        }
+
+        $params = array_merge($params, $this->setContactParams($registrantParams, self::CONTACT_TYPE_REGISTRANT));
+
+        $this->makeRequest($command, $params);
+
+        return $this->getDomainInfo($domainName)['registrant'];
+    }
+
+
+    private function parseContact(array $contact): ContactData
+    {
+        return ContactData::create([
+            'organisation' => (string)$contact['organisation'] ?: null,
+            'name' => $contact['firstname'] . ' ' . $contact['lastname'],
+            'address1' => (string)$contact['address1'],
+            'city' => (string)$contact['suburb'],
+            'state' => (string)$contact['state'] ?: null,
+            'postcode' => (string)$contact['postcode'],
+            'country_code' => Utils::normalizeCountryCode((string)$contact['country']),
+            'email' => (string)$contact['email'],
+            'phone' => (string)$contact['phone'],
+        ]);
+    }
+
+
+    public function initiateTransfer(string $domainName, string $eppCode, ContactParams $contactParams)
+    {
+        $command = 'transferDomain';
+
+        $nameParts = $this->getNameParts($contactParams->name ?? $contactParams->organisation);
+
+        $params = [
+            'domainName' => $domainName,
+            'authInfo' => $eppCode,
+            'firstname' => $nameParts['firstName'],
+            'organisation' => $contactParams->organisation ?: '',
+            'lastname' => $nameParts['lastName'] ?: $nameParts['firstName'],
+            'address' => [$contactParams->address1],
+            'suburb' => $contactParams->city,
+            'state' => $contactParams->state ?: $contactParams->city,
+            'country' => Utils::normalizeCountryCode($contactParams->country_code),
+            'postcode' => $contactParams->postcode,
+            'phone' => Utils::internationalPhoneToEpp($contactParams->phone),
+            'email' => $contactParams->email,
+            'fax' => '',
+            'doRenewal' => false,
+            'idProtect' => false,
+        ];
+
+        $this->makeRequest($command, $params);
+    }
+}

--- a/src/SynergyWholesale/Provider.php
+++ b/src/SynergyWholesale/Provider.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\SynergyWholesale;
+
+use Carbon\Carbon;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Throwable;
+use SoapClient;
+use SoapFault;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionBase\Provider\DataSet\ResultData;
+use Upmind\ProvisionProviders\DomainNames\Category as DomainNames;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppCodeResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppParams;
+use Upmind\ProvisionProviders\DomainNames\Data\IpsTagParams;
+use Upmind\ProvisionProviders\DomainNames\Data\LockParams;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Data\PollParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollResult;
+use Upmind\ProvisionProviders\DomainNames\Data\RegisterDomainParams;
+use Upmind\ProvisionProviders\DomainNames\Data\AutoRenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateDomainContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
+use Upmind\ProvisionProviders\DomainNames\SynergyWholesale\Data\Configuration;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Upmind\ProvisionProviders\DomainNames\SynergyWholesale\Helper\SynergyWholesaleApi;
+
+class Provider extends DomainNames implements ProviderInterface
+{
+    /**
+     * @var Configuration
+     */
+    protected Configuration $configuration;
+
+
+    /**
+     * @var SynergyWholesaleApi
+     */
+    protected SynergyWholesaleApi $api;
+
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('SynergyWholesale')
+            ->setDescription('Register, transfer, renew and manage domains')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/synergywholesale-logo.png');
+    }
+
+    public function domainAvailabilityCheck(DacParams $params): DacResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+
+        $domains = array_map(
+            fn($tld) => $sld . "." . Utils::normalizeTld($tld),
+            $params->tlds
+        );
+
+        $dacDomains = $this->api()->checkMultipleDomains($domains);
+
+        return DacResult::create([
+            'domains' => $dacDomains,
+        ]);
+    }
+
+    public function poll(PollParams $params): PollResult
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    public function register(RegisterDomainParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        if (!$this->configuration->sandbox) { // DAC requests always fail in sandbox
+            $checkResult = $this->api()->checkMultipleDomains([$domainName]);
+
+            if (count($checkResult) < 1) {
+                throw $this->errorResult('Empty domain availability check result');
+            }
+
+            if (!$checkResult[0]->can_register) {
+                throw $this->errorResult('This domain is not available to register');
+            }
+        }
+
+
+        if (!Arr::has($params, 'registrant.register')) {
+            throw $this->errorResult('Registrant contact data is required!');
+        }
+
+        $contacts = [
+            SynergyWholesaleApi::CONTACT_TYPE_REGISTRANT => $params->registrant->register,
+            SynergyWholesaleApi::CONTACT_TYPE_ADMIN => $params->admin->register,
+            SynergyWholesaleApi::CONTACT_TYPE_TECH => $params->tech->register,
+            SynergyWholesaleApi::CONTACT_TYPE_BILLING => $params->billing->register,
+        ];
+
+        try {
+            $this->api()->register(
+                $domainName,
+                intval($params->renew_years),
+                $contacts,
+                $params->nameservers->pluckHosts(),
+            );
+
+            return $this->_getInfo($domainName, sprintf('Domain %s was registered successfully!', $domainName));
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+
+    public function transfer(TransferParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        $eppCode = $params->epp_code ?: '0000';
+
+        try {
+            return $this->_getInfo($domainName, 'Domain active in registrar account');
+        } catch (Throwable $e) {
+            // domain not active - continue below
+        }
+
+        if (!Arr::has($params, 'registrant.register')) {
+            throw $this->errorResult('Registrant contact data is required!');
+        }
+
+        try {
+            $this->api()->initiateTransfer(
+                $domainName,
+                $eppCode,
+                $params->registrant->register,
+            );
+
+            throw $this->errorResult(sprintf('Transfer for %s domain successfully created!', $domainName), [
+                'transaction_id' => null
+            ]);
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function renew(RenewParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+        $period = intval($params->renew_years);
+
+        try {
+            $this->api()->renew($domainName, $period);
+            return $this->_getInfo($domainName, sprintf('Renewal for %s domain was successful!', $domainName));
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function getInfo(DomainInfoParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            return $this->_getInfo($domainName, 'Domain data obtained');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    private function _getInfo(string $domainName, string $message): DomainResult
+    {
+        $domainInfo = $this->api()->getDomainInfo($domainName);
+
+        return DomainResult::create($domainInfo)->setMessage($message);
+    }
+
+    public function updateRegistrantContact(UpdateDomainContactParams $params): ContactResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $contact = $this->api()->updateRegistrantContact($domainName, $params->contact);
+
+            return ContactResult::create($contact);
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function updateNameservers(UpdateNameserversParams $params): NameserversResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $result = $this->api()->updateNameservers(
+                $domainName,
+                $params->pluckHosts(),
+            );
+
+            return NameserversResult::create($result)
+                ->setMessage(sprintf('Name servers for %s domain were updated!', $domainName));
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function setLock(LockParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+        $lock = !!$params->lock;
+
+        try {
+            $currentLockStatus = $this->api()->getRegistrarLockStatus($domainName);
+            if (!$lock && !$currentLockStatus) {
+                return $this->_getInfo($domainName, sprintf('Domain %s already unlocked', $domainName));
+            }
+
+            if ($lock && $currentLockStatus) {
+                return $this->_getInfo($domainName, sprintf('Domain %s already locked', $domainName));
+            }
+
+            $this->api()->setRegistrarLock($domainName, $lock);
+
+            return $this->_getInfo($domainName, sprintf("Lock %s!", $lock ? 'enabled' : 'disabled'));
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function setAutoRenew(AutoRenewParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        $autoRenew = !!$params->auto_renew;
+
+        try {
+            $this->api()->setRenewalMode($domainName, $autoRenew);
+
+            return $this->_getInfo($domainName, 'Auto-renew mode updated');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function getEppCode(EppParams $params): EppCodeResult
+    {
+        $domainName = Utils::getDomain($params->sld, $params->tld);
+
+        try {
+            $eppCode = $this->api()->getDomainEppCode($domainName);
+
+            return EppCodeResult::create([
+                'epp_code' => $eppCode,
+            ])->setMessage('EPP/Auth code obtained');
+        } catch (\Throwable $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function updateIpsTag(IpsTagParams $params): ResultData
+    {
+        throw $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @throws Throwable
+     */
+    protected function handleException(Throwable $e): void
+    {
+        if ($e instanceof SoapFault) {
+            throw $this->errorResult(
+                sprintf('Provider API Error [%s]: %s', $e->getMessage(), ""),
+                ['response_data' => []],
+                [],
+                $e
+            );
+        }
+
+        throw $e;
+    }
+
+    protected function api(): SynergyWholesaleApi
+    {
+        if (isset($this->api)) {
+            return $this->api;
+        }
+
+        $client = new SoapClient("https://api.synergywholesale.com/?wsdl");
+
+        return $this->api = new SynergyWholesaleApi($client, $this->configuration);
+    }
+
+}


### PR DESCRIPTION
The following operations are implemented for SynergyWholesale:

domainAvailabilityCheck()
setAutoRenew()
register()
transfer() - not tested, because we have only a live account
renew()
getInfo()
updateRegistrantContact()
updateNameservers();
setLock()
getEppCode()

The following operations aren't supported by SynergyWholesale:

poll()
updateIpsTag()