### PR TITLE
Add Norid implementation

### DIFF
--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -35,6 +35,7 @@ use Upmind\ProvisionProviders\DomainNames\InternetX\Provider as InternetX;
 use Upmind\ProvisionProviders\DomainNames\EURID\Provider as EURID;
 use Upmind\ProvisionProviders\DomainNames\TPPWholesale\Provider as TPPWholesale;
 use Upmind\ProvisionProviders\DomainNames\SynergyWholesale\Provider as SynergyWholesale;
+use Upmind\ProvisionProviders\DomainNames\Norid\Provider as Norid;
 
 class LaravelServiceProvider extends ProvisionServiceProvider
 {
@@ -73,5 +74,6 @@ class LaravelServiceProvider extends ProvisionServiceProvider
         $this->bindProvider('domain-names', 'eurid', EURID::class);
         $this->bindProvider('domain-names', 'tpp-wholesale', TPPWholesale::class);
         $this->bindProvider('domain-names', 'synergy-wholesale', SynergyWholesale::class);
+        $this->bindProvider('domain-names', 'norid', Norid::class);
     }
 }

--- a/src/Norid/Data/Configuration.php
+++ b/src/Norid/Data/Configuration.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Norid\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * Norid configuration.
+ *
+ * @property-read string $username
+ * @property-read string $password
+ * @property-read bool|null $sandbox
+ */
+class Configuration extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'username' => ['required', 'string', 'min:3'],
+            'password' => ['required', 'string', 'min:6'],
+            'sandbox' => ['nullable', 'boolean'],
+        ]);
+    }
+}

--- a/src/Norid/Data/Configuration.php
+++ b/src/Norid/Data/Configuration.php
@@ -12,6 +12,7 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  *
  * @property-read string $username
  * @property-read string $password
+ * @property-read string $organisationNumber
  * @property-read bool|null $sandbox
  */
 class Configuration extends DataSet
@@ -21,6 +22,7 @@ class Configuration extends DataSet
         return new Rules([
             'username' => ['required', 'string', 'min:3'],
             'password' => ['required', 'string', 'min:6'],
+            'organisationNumber' => ['required', 'string'],
             'sandbox' => ['nullable', 'boolean'],
         ]);
     }

--- a/src/Norid/EppExtension/EppConnection.php
+++ b/src/Norid/EppExtension/EppConnection.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Norid\EppExtension;
+
+use Metaregistrar\EPP\eppConnection as BaseEppConnection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class EppConnection
+ * @package Upmind\ProvisionProviders\DomainNames\Norid\EppExtension
+ */
+class EppConnection extends BaseEppConnection
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected LoggerInterface $logger;
+
+    /**
+     * EppConnection constructor.
+     * @param bool $logging
+     * @param string|null $settingsFile
+     */
+    public function __construct(bool $logging = false, string $settingsFile = null)
+    {
+        // Call parent's constructor
+        parent::__construct($logging, $settingsFile);
+
+        parent::enableDnssec();
+
+        // Define supported EPP services
+        parent::setServices(array(
+            'urn:ietf:params:xml:ns:domain-1.0' => 'domain',
+            'urn:ietf:params:xml:ns:contact-1.0' => 'contact',
+            'urn:ietf:params:xml:ns:host-1.0' => 'host'
+        ));
+
+        parent::useExtension('authInfo-1.1');
+
+        // Add registry-specific EPP extensions
+        parent::useExtension('no-ext-epp-1.0');
+        parent::useExtension('no-ext-result-1.0');
+        parent::useExtension('no-ext-domain-1.1');
+        parent::useExtension('no-ext-contact-1.0');
+        parent::useExtension('no-ext-host-1.0');
+    }
+
+    /**
+     * Set a PSR-3 logger.
+     */
+    public function setPsrLogger(?LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+        if (isset($logger)) {
+            $this->logFile = '/dev/null';
+        }
+    }
+
+    /**
+     * Writes a log message to the log file or PSR-3 logger.
+     *
+     * @inheritdoc
+     */
+    public function writeLog($text, $action)
+    {
+        if ($this->logging && isset($this->logger)) {
+            $message = $text;
+            $message = $this->hideTextBetween($message, '<clID>', '</clID>');
+            // Hide password in the logging
+            $message = $this->hideTextBetween($message, '<pw>', '</pw>');
+            $message = $this->hideTextBetween($message, '<pw><![CDATA[', ']]></pw>');
+            // Hide new password in the logging
+            $message = $this->hideTextBetween($message, '<newPW>', '</newPW>');
+            $message = $this->hideTextBetween($message, '<newPW><![CDATA[', ']]></newPW>');
+            // Hide domain password in the logging
+            $message = $this->hideTextBetween($message, '<domain:pw>', '</domain:pw>');
+            $message = $this->hideTextBetween($message, '<domain:pw><![CDATA[', ']]></domain:pw>');
+            // Hide contact password in the logging
+            $message = $this->hideTextBetween($message, '<contact:pw>', '</contact:pw>');
+            $message = $this->hideTextBetween($message, '<contact:pw><![CDATA[', ']]></contact:pw>');
+
+            $this->logger->debug(sprintf("Norid [%s]:\n %s", $action, trim($message)));
+        }
+
+        parent::writeLog($text, $action);
+    }
+}

--- a/src/Norid/Helper/NoridApi.php
+++ b/src/Norid/Helper/NoridApi.php
@@ -318,7 +318,7 @@ class NoridApi
             $params->organisation,
             $params->address1,
             '',
-            $params->postcode,
+            'NO-'.$params->postcode,
             eppContact::TYPE_LOC,
         );
 
@@ -458,7 +458,7 @@ class NoridApi
         return Helper::generateStrictPassword($length, true, true, true, '-_.');
     }
 
-    public function createContact(ContactParams $params, string $contactType = "role", string $organisationNumber = ""): string
+    public function createContact(ContactParams $params, string $contactType = "role"): string
     {
         $telephone = null;
         if ($params->phone) {
@@ -483,7 +483,7 @@ class NoridApi
             $org,
             $params->address1,
             '',
-            $params->postcode,
+            'NO-'.$params->postcode,
             eppContact::TYPE_LOC,
         );
 
@@ -492,7 +492,7 @@ class NoridApi
         $contactInfo->setExtType($contactType);
 
         if ($contactType == "organization") {
-            $contactInfo->setExtIdentity('organizationNumber', $organisationNumber);
+            $contactInfo->setExtIdentity('organizationNumber', $this->configuration->organisationNumber);
             $contactInfo->setExtMobilePhone($telephone);
         }
 

--- a/src/Norid/Helper/NoridApi.php
+++ b/src/Norid/Helper/NoridApi.php
@@ -1,0 +1,532 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Norid\Helper;
+
+use Carbon\Carbon;
+use DateTime;
+use Upmind\ProvisionBase\Helper;
+use Metaregistrar\EPP\authEppInfoDomainRequest;
+use Metaregistrar\EPP\authEppInfoDomainResponse;
+use Metaregistrar\EPP\eppCheckDomainRequest;
+use Metaregistrar\EPP\eppCheckDomainResponse;
+use Metaregistrar\EPP\eppCheckRequest;
+use Metaregistrar\EPP\eppPollResponse;
+use Metaregistrar\EPP\eppPollRequest;
+use Metaregistrar\EPP\eppContact;
+use Metaregistrar\EPP\eppContactHandle;
+use Metaregistrar\EPP\eppContactPostalInfo;
+use Metaregistrar\EPP\eppCreateContactRequest;
+use Metaregistrar\EPP\eppCreateContactResponse;
+use Metaregistrar\EPP\eppCreateDomainRequest;
+use Metaregistrar\EPP\eppCreateDomainResponse;
+use Metaregistrar\EPP\eppCreateHostRequest;
+use Metaregistrar\EPP\eppDomain;
+use Metaregistrar\EPP\eppException;
+use Metaregistrar\EPP\eppHost;
+use Metaregistrar\EPP\eppInfoContactRequest;
+use Metaregistrar\EPP\eppInfoContactResponse;
+use Metaregistrar\EPP\eppInfoDomainRequest;
+use Metaregistrar\EPP\eppInfoDomainResponse;
+use Metaregistrar\EPP\eppRenewRequest;
+use Metaregistrar\EPP\eppTransferRequest;
+use Metaregistrar\EPP\eppTransferResponse;
+use Metaregistrar\EPP\eppUpdateDomainRequest;
+use Metaregistrar\EPP\eppUpdateDomainResponse;
+use Metaregistrar\EPP\eppUpdateContactRequest;
+use Metaregistrar\EPP\noridEppContact;
+use Metaregistrar\EPP\noridEppDomain;
+use Metaregistrar\EPP\noridEppCreateDomainRequest;
+use Metaregistrar\EPP\noridEppCreateDomainResponse;
+use Metaregistrar\EPP\noridEppCreateContactRequest;
+use Metaregistrar\EPP\noridEppInfoContactResponse;
+use Metaregistrar\EPP\noridEppInfoContactRequest;
+use Metaregistrar\EPP\noridEppUpdateDomainRequest;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionProviders\DomainNames\Norid\EppExtension\EppConnection;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacDomain;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainNotification;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+use Upmind\ProvisionProviders\DomainNames\Norid\Data\Configuration;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactData;
+
+/**
+ * Class NoridHelper
+ *
+ * @package Upmind\ProvisionProviders\DomainNames\Norid\Helper
+ */
+class NoridApi
+{
+    protected EppConnection $connection;
+    protected Configuration $configuration;
+
+    protected array $lockedStatuses = [
+        'serverTransferProhibited',
+        'clientUpdateProhibited',
+    ];
+
+    public function __construct(EppConnection $connection, Configuration $configuration)
+    {
+        $this->connection = $connection;
+        $this->configuration = $configuration;
+    }
+
+
+    public function poll(int $limit, ?Carbon $since): array
+    {
+        $notifications = [];
+        $countRemaining = 0;
+
+        /**
+         * Start a timer because there may be 1000s of irrelevant messages and we should try and avoid a timeout.
+         */
+        $timeLimit = 60; // 60 seconds
+        $startTime = time();
+
+        while (count($notifications) < $limit && (time() - $startTime) < $timeLimit) {
+            // get oldest message from queue
+            /** @var eppPollResponse $pollResponse */
+            $pollResponse = $this->connection->request(new eppPollRequest(eppPollRequest::POLL_REQ, 0));
+            $countRemaining = $pollResponse->getMessageCount();
+
+            if ($countRemaining == 0) {
+                break;
+            }
+
+            $messageId = $pollResponse->getMessageId();
+            $type = $pollResponse->getMessageType();
+            $message = $pollResponse->getMessage() ?: 'Domain Notification';
+            $domain = $pollResponse->getDomainName();
+            $messageDateTime = Carbon::parse($pollResponse->getMessageDate());
+
+            $this->connection->request(new eppPollRequest(eppPollRequest::POLL_ACK, $messageId));
+
+            if ($type != eppPollResponse::TYPE_TRANSFER) {
+                // this message is irrelevant
+                continue;
+            }
+
+            if (isset($since) && $messageDateTime->lessThan($since)) {
+                // this message is too old
+                continue;
+            }
+
+            $notifications[] = DomainNotification::create()
+                ->setId($messageId)
+                ->setType(DomainNotification::TYPE_TRANSFER_IN)
+                ->setMessage($message)
+                ->setDomains([$domain])
+                ->setCreatedAt($messageDateTime)
+                ->setExtra(['xml' => $pollResponse->saveXML()]);
+        }
+
+        return [
+            'count_remaining' => $countRemaining,
+            'notifications' => $notifications,
+        ];
+    }
+
+    public function checkMultipleDomains(array $domains): array
+    {
+        $check = new eppCheckDomainRequest($domains);
+
+        /** @var eppCheckDomainResponse */
+        $response = $this->connection->request($check);
+
+        $checks = $response->getCheckedDomains();
+
+        $result = [];
+
+        foreach ($checks as $check) {
+            $available = (bool)$check['available'] == "true";
+
+            $premium = false;
+
+            $description = sprintf(
+                'Domain is %s to register. %s',
+                $available ? 'available' : 'not available',
+                $check['reason'],
+            );
+
+            $canTransfer = !$available;
+            if (!$available && strtolower($check['reason']) === 'invalid domain') {
+                $canTransfer = false;
+            }
+
+            $result[] = DacDomain::create([
+                'domain' => $check['domainname'],
+                'description' => $description,
+                'tld' => Utils::getTld($check['domainname']),
+                'can_register' => $available,
+                'can_transfer' => $canTransfer,
+                'is_premium' => $premium,
+            ]);
+        }
+
+        return $result;
+    }
+
+    public function register(
+        string $domainName,
+        int    $period,
+        array  $contacts,
+        array  $nameServers
+    ): array
+    {
+        $domain = new noridEppDomain($domainName, $contacts[eppContactHandle::CONTACT_TYPE_REGISTRANT], [
+            new eppContactHandle($contacts[eppContactHandle::CONTACT_TYPE_TECH], eppContactHandle::CONTACT_TYPE_TECH)
+        ]);
+
+        $domain->setAuthorisationCode(self::generateValidAuthCode());
+        $date = new DateTime();
+        $domain->setExtApplicantDataset('3.2', $contacts[eppContactHandle::CONTACT_TYPE_REGISTRANT], $date->format("Y-m-d\TH:i:s.v\Z"));
+
+        $this->createNameServers($nameServers);
+
+        foreach ($nameServers as $nameserver) {
+            $domain->addHost(new eppHost($nameserver));
+        }
+
+        // Set Domain Period
+        $domain->setPeriod($period);
+        $domain->setPeriodUnit('y');
+
+        // Create the domain
+        $create = new noridEppCreateDomainRequest($domain);
+
+        /** @var noridEppCreateDomainResponse $response */
+        $response = $this->connection->request($create);
+
+        return [
+            'domain' => $response->getDomainName(),
+            'created_at' => Utils::formatDate($response->getDomainCreateDate()),
+            'expires_at' => Utils::formatDate($response->getDomainExpirationDate())
+        ];
+    }
+
+    public function initiateTransfer(string $domainName, ?string $eppCode, int $renewYears): eppTransferResponse
+    {
+        $domain = new eppDomain($domainName);
+
+        // Set EPP Code
+        if ($eppCode != null) {
+            $domain->setAuthorisationCode($eppCode);
+        }
+
+        $domain->setPeriod($renewYears);
+        $domain->setPeriodUnit('y');
+
+        $transferRequest = new eppTransferRequest(eppTransferRequest::OPERATION_REQUEST, $domain);
+
+        // Process Response
+        /** @var eppTransferResponse */
+        return $this->connection->request($transferRequest);
+    }
+
+    public function renew(string $domainName): void
+    {
+        $domainData = new eppDomain($domainName);
+        $domainData->setPeriod(1);
+        $domainData->setPeriodUnit('y');
+
+        $info = new eppInfoDomainRequest($domainData);
+        /** @var eppInfoDomainResponse $response */
+        $response = $this->connection->request($info);
+
+        $expiresAt = Utils::formatDate($response->getDomainExpirationDate(), 'Y-m-d');
+
+        $renewRequest = new eppRenewRequest($domainData, $expiresAt);
+
+        $this->connection->request($renewRequest);
+    }
+
+    /**
+     * @throws \Metaregistrar\EPP\eppException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getDomainInfo(string $domainName, bool $checkRegistrar = true): array
+    {
+        $domain = new eppDomain($domainName);
+        $info = new eppInfoDomainRequest($domain);
+
+        /** @var eppInfoDomainResponse */
+        $response = $this->connection->request($info);
+
+        if ($checkRegistrar && $response->getDomainClientId() !== $this->configuration->username) {
+            throw new ProvisionFunctionError('Domain not owned by registrar account');
+        }
+
+        $registrantId = $response->getDomainRegistrant();
+        $billingId = $response->getDomainContact(eppContactHandle::CONTACT_TYPE_BILLING);
+        $techId = $response->getDomainContact(eppContactHandle::CONTACT_TYPE_TECH);
+        $adminId = $response->getDomainContact(eppContactHandle::CONTACT_TYPE_ADMIN);
+
+        return [
+            'id' => $response->getDomainId(),
+            'domain' => $response->getDomainName(),
+            'statuses' => $response->getDomainStatuses() ?? [],
+            'locked' => boolval(array_intersect($this->lockedStatuses, $response->getDomainStatuses() ?? [])),
+            'registrant' => $registrantId ? $this->getContactInfo($registrantId) : null,
+            'billing' => $billingId ? $this->getContactInfo($billingId) : null,
+            'tech' => $techId ? $this->getContactInfo($techId) : null,
+            'admin' => $adminId ? $this->getContactInfo($adminId) : null,
+            'ns' => $this->parseNameServers($response->getDomainNameservers() ?? []),
+            'created_at' => Utils::formatDate($response->getDomainCreateDate()),
+            'updated_at' => Utils::formatDate($response->getDomainUpdateDate() ?: $response->getDomainCreateDate()),
+            'expires_at' => Utils::formatDate($response->getDomainExpirationDate()),
+        ];
+    }
+
+    public function updateRegistrantContact(string $domainName, ContactParams $params): ContactData
+    {
+        $domain = new eppDomain($domainName);
+        $info = new eppInfoDomainRequest($domain);
+
+        /** @var \Metaregistrar\EPP\eppInfoDomainResponse $response */
+        $response = $this->connection->request($info);
+        $registrantId = $response->getDomainRegistrant();
+
+        $contact = new eppContactHandle($registrantId);
+
+        $update = $this->setUpdateContactParams($params);
+
+        $up = new eppUpdateContactRequest($contact, null, null, $update);
+
+        $this->connection->request($up);
+
+        return $this->getContactInfo($registrantId);
+    }
+
+    private function setUpdateContactParams(ContactParams $params): eppContact
+    {
+        $telephone = null;
+        if ($params->phone) {
+            $telephone = Utils::internationalPhoneToEpp($params->phone);
+        }
+
+        $countryCode = null;
+        if ($params->country_code) {
+            $countryCode = Utils::normalizeCountryCode($params->country_code);
+        }
+
+        $postalInfo = new eppContactPostalInfo(
+            $params->name ?: $params->organisation,
+            $params->city,
+            $countryCode,
+            $params->organisation,
+            $params->address1,
+            '',
+            $params->postcode,
+            eppContact::TYPE_LOC,
+        );
+
+        return new eppContact($postalInfo, $params->email, $telephone);
+    }
+
+    public function getEppCode(string $domainName): ?string
+    {
+        $domain = new eppDomain($domainName);
+        $info = new authEppInfoDomainRequest($domain);
+
+        /** @var authEppInfoDomainResponse $response */
+        $response = $this->connection->request($info);
+
+        return $response->getDomainAuthInfo();
+    }
+
+
+    /**
+     * @throws \Metaregistrar\EPP\eppException
+     */
+    public function updateNameservers(string $domainName, array $nameservers): void
+    {
+        $attachedHosts = $this->getHosts($domainName);
+        if (array_diff($attachedHosts, $nameservers) == array_diff($nameservers, $attachedHosts)) {
+            return;
+        }
+
+        $this->createNameServers($nameservers);
+
+        if ($attachedHosts) {
+            $removeInfo = new eppDomain($domainName);
+            foreach ($attachedHosts as $ns) {
+                if (in_array($ns, $nameservers)) {
+                    continue;
+                }
+
+                $removeInfo->addHost(new eppHost($ns));
+            }
+        }
+
+        $addInfo = new eppDomain($domainName);
+
+        foreach ($nameservers as $nameserver) {
+            if (!in_array($nameserver, $attachedHosts)) {
+                $addInfo->addHost(new eppHost($nameserver));
+            }
+        }
+
+        $update = new eppUpdateDomainRequest(
+            new eppDomain($domainName),
+            $addInfo,
+            $removeInfo ?? null,
+            null
+        );
+
+        $this->connection->request($update);
+    }
+
+    public function getContactInfo(string $contactId): ContactData
+    {
+        $request = new noridEppInfoContactRequest(new eppContactHandle($contactId), false);
+        try {
+            /** @var noridEppInfoContactResponse $response */
+            $response = $this->connection->request($request);
+        } catch (eppException $e) {
+            return ContactData::create(['id' => $contactId]);
+        }
+
+        return ContactData::create([
+            'id' => $contactId,
+            'name' => $response->getContactName(),
+            'email' => $response->getContactEmail(),
+            'phone' => $response->getExtMobilePhone(),
+            'organisation' => $response->getContactCompanyname(),
+            'address1' => $response->getContactStreet(),
+            'city' => $response->getContactCity(),
+            'postcode' => $response->getContactZipcode(),
+            'country_code' => $response->getContactCountrycode(),
+            'type' => $response->getExtType(),
+        ]);
+    }
+
+    private function parseNameServers(array $nameServers): array
+    {
+        $result = [];
+
+        if (count($nameServers) > 0) {
+            foreach ($nameServers as $i => $ns) {
+                $result['ns' . ($i + 1)] = [
+                    'host' => $ns->getHostName(),
+                    'ip' => $ns->getIpAddresses()
+                ];
+            }
+        }
+
+        return $result;
+    }
+
+    public function getHosts(string $domainName): ?array
+    {
+        $domain = new eppDomain($domainName);
+        $info = new eppInfoDomainRequest($domain);
+
+        /** @var eppInfoDomainResponse */
+        $response = $this->connection->request($info);
+
+        $nameservers = $response->getDomainNameservers();
+
+        $attachedHosts = [];
+        if ($nameservers) {
+            foreach ($nameservers as $ns) {
+                $attachedHosts[] = $ns->getHostname();
+            }
+        }
+
+        return $attachedHosts;
+    }
+
+    /**
+     * @throws \Metaregistrar\EPP\eppException
+     */
+    private function createHost(string $host, ?string $ip): void
+    {
+        $create = new eppCreateHostRequest(new eppHost($host, $ip));
+
+        $this->connection->request($create);
+    }
+
+    /**
+     * Generates a random auth code containing lowercase letters, uppercase letters, numbers and special characters.
+     *
+     * @return string
+     */
+    private static function generateValidAuthCode(int $length = 16): string
+    {
+        return Helper::generateStrictPassword($length, true, true, true, '-_.');
+    }
+
+    public function createContact(ContactParams $params, string $contactType = "role", string $organisationNumber = ""): string
+    {
+        $telephone = null;
+        if ($params->phone) {
+            $telephone = Utils::internationalPhoneToEpp($params->phone);
+        }
+
+        $countryCode = null;
+        if ($params->country_code) {
+            $countryCode = Utils::normalizeCountryCode($params->country_code);
+        }
+
+        $org = '';
+
+        if ($contactType == "organization") {
+            $org = $params->organisation;
+        }
+
+        $postalInfo = new eppContactPostalInfo(
+            $params->name ?: $params->organisation,
+            $params->city,
+            $countryCode,
+            $org,
+            $params->address1,
+            '',
+            $params->postcode,
+            eppContact::TYPE_LOC,
+        );
+
+        $contactInfo = new noridEppContact($postalInfo, $params->email, null, null, ' ');
+
+        $contactInfo->setExtType($contactType);
+
+        if ($contactType == "organization") {
+            $contactInfo->setExtIdentity('organizationNumber', $organisationNumber);
+            $contactInfo->setExtMobilePhone($telephone);
+        }
+
+        $contact = new noridEppCreateContactRequest($contactInfo);
+
+        /** @var eppCreateContactResponse $response */
+        $response = $this->connection->request($contact);
+
+        return $response->getContactId();
+    }
+
+    private function createNameServers(array $nameservers)
+    {
+        $uncreatedHosts = $this->checkUncreatedHosts($nameservers);
+
+        foreach ($nameservers as $nameserver) {
+            if (!empty($uncreatedHosts[$nameserver])) {
+                $this->createHost($nameserver, null);
+            }
+        }
+
+    }
+
+    private function checkUncreatedHosts(array $nameservers): ?array
+    {
+        $checkHost = [];
+        foreach ($nameservers as $host) {
+            $checkHost[] = new eppHost($host);
+        }
+
+        $check = new eppCheckRequest($checkHost);
+        /** @var \Metaregistrar\EPP\eppCheckResponse|null $response */
+        $response = $this->connection->request($check);
+
+        return $response?->getCheckedHosts();
+    }
+}

--- a/src/Norid/Provider.php
+++ b/src/Norid/Provider.php
@@ -174,7 +174,7 @@ class Provider extends DomainNames implements ProviderInterface
             }
 
             $registrantID = $this->api()->createContact(
-                $params->registrant->register, "organization", $params->additional_fields[0]
+                $params->registrant->register, "organization"
             );
         }
 

--- a/src/Norid/Provider.php
+++ b/src/Norid/Provider.php
@@ -1,0 +1,514 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\DomainNames\Norid;
+
+use Carbon\Carbon;
+use ErrorException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Metaregistrar\EPP\eppException;
+use Metaregistrar\EPP\eppContactHandle;
+use SimpleXMLElement;
+use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
+use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
+use Upmind\ProvisionBase\Provider\DataSet\AboutData;
+use Upmind\ProvisionBase\Provider\DataSet\ResultData;
+use Upmind\ProvisionProviders\DomainNames\Category as DomainNames;
+use Upmind\ProvisionProviders\DomainNames\Data\ContactResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DacParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DacResult;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainInfoParams;
+use Upmind\ProvisionProviders\DomainNames\Data\DomainResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppCodeResult;
+use Upmind\ProvisionProviders\DomainNames\Data\EppParams;
+use Upmind\ProvisionProviders\DomainNames\Data\IpsTagParams;
+use Upmind\ProvisionProviders\DomainNames\Data\NameserversResult;
+use Upmind\ProvisionProviders\DomainNames\Data\RegisterDomainParams;
+use Upmind\ProvisionProviders\DomainNames\Data\RenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\LockParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollParams;
+use Upmind\ProvisionProviders\DomainNames\Data\PollResult;
+use Upmind\ProvisionProviders\DomainNames\Data\AutoRenewParams;
+use Upmind\ProvisionProviders\DomainNames\Data\TransferParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateDomainContactParams;
+use Upmind\ProvisionProviders\DomainNames\Data\UpdateNameserversParams;
+use Upmind\ProvisionProviders\DomainNames\Norid\Data\Configuration;
+use Upmind\ProvisionProviders\DomainNames\Norid\EppExtension\EppConnection;
+use Upmind\ProvisionProviders\DomainNames\Norid\Helper\NoridApi;
+use Upmind\ProvisionProviders\DomainNames\Helper\Utils;
+
+/**
+ * Class Provider
+ *
+ * @package Upmind\ProvisionProviders\DomainNames\Norid
+ */
+class Provider extends DomainNames implements ProviderInterface
+{
+    protected Configuration $configuration;
+
+    protected EppConnection|null $connection = null;
+
+    protected NoridApi|null $api = null;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @throws \Metaregistrar\EPP\eppException
+     */
+    public function __destruct()
+    {
+        if (isset($this->connection) && $this->connection->isLoggedin()) {
+            $this->connection->logout();
+        }
+    }
+
+    public static function aboutProvider(): AboutData
+    {
+        return AboutData::create()
+            ->setName('Norid')
+            ->setLogoUrl('https://api.upmind.io/images/logos/provision/norid-logo@2x.png')
+            ->setDescription('Register, transfer, renew and manage Norid domains');
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function poll(PollParams $params): PollResult
+    {
+        $since = $params->after_date ? Carbon::parse($params->after_date) : null;
+
+        try {
+            $poll = $this->api()->poll(intval($params->limit), $since);
+            return PollResult::create($poll);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function domainAvailabilityCheck(DacParams $params): DacResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+        $domains = array_map(
+            fn ($tld) => $sld . "." . Utils::normalizeTld($tld),
+            $params->tlds
+        );
+
+        try {
+            $dacDomains = $this->api()->checkMultipleDomains($domains);
+
+            return DacResult::create([
+                'domains' => $dacDomains,
+            ]);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function register(RegisterDomainParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        if (count($params->nameservers->pluckHosts()) < 2) {
+            $this->errorResult('Too few nameservers, minimum is [2]');
+        }
+
+        $checkResult = $this->api()->checkMultipleDomains([$domainName]);
+
+        if (count($checkResult) < 1) {
+            $this->errorResult('Empty domain availability check result');
+        }
+
+        if (!$checkResult[0]->can_register) {
+            if (!$checkResult[0]->can_transfer) {
+                $this->errorResult('This domain is not supported');
+            }
+
+            $this->errorResult($checkResult[0]->description);
+        }
+
+        $contacts = $this->getRegisterParams($params);
+
+        try {
+            $this->api()->register(
+                $domainName,
+                intval($params->renew_years),
+                $contacts,
+                $params->nameservers->pluckHosts(),
+            );
+
+            return $this->_getInfo($domainName, sprintf('Domain %s was registered successfully!', $domainName));
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function getRegisterParams(RegisterDomainParams $params): array
+    {
+        if (Arr::has($params, 'registrant.id')) {
+            $registrantID = $params->registrant->id;
+
+            // Check if the registrant ID is valid, as long as the returned data are not empty (excluding id)
+            if ($this->isDataArrayEmpty($this->api()->getContactInfo($registrantID)->toArray(), ['id'])) {
+                $this->errorResult("Invalid registrant ID provided!", $params);
+            }
+        } else {
+            if (!Arr::has($params, 'registrant.register')) {
+                $this->errorResult('Registrant contact data is required!');
+            }
+
+            $registrantID = $this->api()->createContact(
+                $params->registrant->register, "organization", $params->additional_fields[0]
+            );
+        }
+
+
+        if (Arr::has($params, 'tech.id')) {
+            $techID = $params->tech->id;
+
+            if ($this->isDataArrayEmpty($this->api()->getContactInfo($techID)->toArray(), ['id'])) {
+                $this->errorResult("Invalid registrant ID provided!", $params);
+            }
+        } else {
+            if (!Arr::has($params, 'tech.register')) {
+                $this->errorResult('Tech contact data is required!');
+            }
+
+            $techID = $this->api()->createContact(
+                $params->tech->register,
+            );
+        }
+
+
+        return [
+            eppContactHandle::CONTACT_TYPE_REGISTRANT => $registrantID,
+            eppContactHandle::CONTACT_TYPE_TECH => $techID,
+        ];
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function transfer(TransferParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        $eppCode = $params->epp_code ?: null;
+
+        try {
+            return $this->_getInfo($domainName, 'Domain active in registrar account');
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        } catch (ProvisionFunctionError $e) {
+            if ($e->getMessage() !== 'Domain not owned by registrar account') {
+                throw $e;
+            }
+
+            // continue on to initiate transfer
+        }
+
+        try {
+            $transferId = $this->api()->initiateTransfer($domainName, $eppCode, intval($params->renew_years));
+
+            $this->errorResult(sprintf('Transfer for %s domain successfully created!', $domainName), ['transfer_id' => $transferId]);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function renew(RenewParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        $period = intval($params->renew_years);
+
+        if ($period != 1) {
+            $this->errorResult('Renewal period must be 1 year.');
+        }
+
+        try {
+            $this->_getInfo($domainName, 'Domain active in registrar account');
+
+
+            $this->api()->renew($domainName);
+
+            return $this->_getInfo($domainName, sprintf('Renewal for %s domain was successful!', $domainName));
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getInfo(DomainInfoParams $params): DomainResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        try {
+            return $this->_getInfo($domainName);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    /**
+     * @throws \Metaregistrar\EPP\eppException
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function _getInfo(string $domain, $msg = 'Domain data obtained'): DomainResult
+    {
+        $domainInfo = $this->api()->getDomainInfo($domain);
+
+        return DomainResult::create($domainInfo, false)->setMessage($msg);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function updateRegistrantContact(UpdateDomainContactParams $params): ContactResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+        try {
+            $this->_getInfo($domainName, 'Domain active in registrar account');
+
+            $contact = $this->api()->updateRegistrantContact($domainName, $params->contact);
+
+            return ContactResult::create($contact);
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function updateNameservers(UpdateNameserversParams $params): NameserversResult
+    {
+        $sld = Utils::normalizeSld($params->sld);
+        $tld = Utils::normalizeTld($params->tld);
+
+        $domainName = Utils::getDomain($sld, $tld);
+
+        try {
+            $this->_getInfo($domainName, 'Domain active in registrar account');
+
+            $this->api()->updateNameServers($domainName, array_unique($params->pluckHosts()));
+
+            $hosts = $this->api()->getHosts($domainName);
+
+            $returnNameservers = [];
+            foreach ($hosts as $i => $ns) {
+                $returnNameservers['ns' . ($i + 1)] = $ns;
+            }
+
+            return NameserversResult::create($returnNameservers)
+                ->setMessage(sprintf('Name servers for %s domain were updated!', $domainName));
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e, $params->toArray());
+        }
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function setLock(LockParams $params): DomainResult
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function setAutoRenew(AutoRenewParams $params): DomainResult
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function getEppCode(EppParams $params): EppCodeResult
+    {
+        $domainName = Utils::getDomain(
+            Utils::normalizeSld($params->sld),
+            Utils::normalizeTld($params->tld)
+        );
+
+
+        try {
+            $this->_getInfo($domainName, 'Domain active in registrar account');
+
+            $eppCode = $this->api()->getEppcode($domainName);
+
+            return EppCodeResult::create([
+                'epp_code' => $eppCode,
+            ])->setMessage('EPP/Auth code obtained');
+        } catch (eppException $e) {
+            $this->_eppExceptionHandler($e);
+        }
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    public function updateIpsTag(IpsTagParams $params): ResultData
+    {
+        $this->errorResult('Operation not supported');
+    }
+
+    /**
+     * @return no-return
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    private function _eppExceptionHandler(eppException $exception, array $data = [], array $debug = []): void
+    {
+        if ($response = $exception->getResponse()) {
+            $debug['response_xml'] = $response->saveXML();
+        }
+
+        switch ($exception->getCode()) {
+            case 2001:
+                $errorMessage = 'Invalid request data';
+                break;
+            case 2201:
+                $errorMessage = 'Permission denied';
+                break;
+            default:
+                $errorMessage = $exception->getMessage();
+                try {
+                    $xml = new SimpleXMLElement($debug['response_xml']);
+                    $xml->registerXPathNamespace('norid', 'http://www.norid.no/xsd/no-ext-result-1.0');
+                    $conditions = $xml->xpath('//norid:conditions/norid:condition');
+                    $details = '';
+                    foreach ($conditions as $condition) {
+                        $details .= $condition->details . " ";
+                    }
+
+                    $this->errorResult(sprintf("Registry Error: %s Details: %s", $errorMessage, $details), $data, $debug, $exception);
+
+                } catch (Exception $e) {
+                }
+        }
+
+        $this->errorResult(sprintf('Registry Error: %s', $errorMessage), $data, $debug, $exception);
+    }
+
+    /**
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
+     */
+    protected function connect(): EppConnection
+    {
+        try {
+            if (!isset($this->connection) || !$this->connection->isConnected() || !$this->connection->isLoggedin()) {
+                $connection = new EppConnection(true);
+                $connection->setPsrLogger($this->getLogger());
+
+                // Set connection data
+                $connection->setHostname($this->resolveAPIURL());
+                $connection->setPort(700);
+                $connection->setUsername($this->configuration->username);
+                $connection->setPassword($this->configuration->password);
+
+                $connection->login();
+
+                return $this->connection = $connection;
+            }
+
+            return $this->connection;
+        } catch (eppException $e) {
+            switch ($e->getCode()) {
+                case 2001:
+                case 2400:
+                    $errorMessage = 'Authentication error; check credentials';
+                    break;
+                case 2200:
+                    $errorMessage = 'Authentication error; check credentials and whitelisted IPs';
+                    break;
+                default:
+                    $errorMessage = 'Unexpected provider connection error';
+            }
+
+            $this->errorResult(trim(sprintf('%s %s', $e->getCode() ?: null, $errorMessage)), [], [], $e);
+        } catch (ErrorException $e) {
+            if (Str::containsAll($e->getMessage(), ['stream_socket_client()', 'SSL'])) {
+                // this usually means they've not whitelisted our IPs
+                $errorMessage = 'Connection error; check whitelisted IPs';
+            } else {
+                $errorMessage = 'Unexpected provider connection error';
+            }
+
+            $this->errorResult($errorMessage, [], [], $e);
+        }
+    }
+
+    private function api(): NoridApi
+    {
+        if (isset($this->api)) {
+            return $this->api;
+        }
+
+        $this->connect();
+
+        return $this->api ??= new NoridApi($this->connection, $this->configuration);
+    }
+
+
+    private function resolveAPIURL(): string
+    {
+        return $this->configuration->sandbox
+            ? 'ssl://epp.test.norid.no'
+            : 'ssl://epp.norid.no';
+    }
+
+    /**
+     * Check whether all the array values are empty, excluding the values of the ignored keys if provided.
+     */
+    private function isDataArrayEmpty(array $data, array $ignoredKeys = []): bool
+    {
+        foreach ($data as $key => $value) {
+            if (in_array($key, $ignoredKeys, true)) {
+                continue;
+            }
+
+            if (!empty($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Norid/Provider.php
+++ b/src/Norid/Provider.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 use Metaregistrar\EPP\eppException;
 use Metaregistrar\EPP\eppContactHandle;
 use SimpleXMLElement;
+use Throwable;
 use Upmind\ProvisionBase\Exception\ProvisionFunctionError;
 use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
@@ -420,7 +421,7 @@ class Provider extends DomainNames implements ProviderInterface
 
                     $this->errorResult(sprintf("Registry Error: %s Details: %s", $errorMessage, $details), $data, $debug, $exception);
 
-                } catch (Exception $e) {
+                } catch (Throwable $e) {
                 }
         }
 


### PR DESCRIPTION
The following operations are implemented for Norid:

- poll()
- domainAvailabilityCheck()
- register() - **Admin, Billing contacts not supported. To create a registrant contact, an organisation number is required. This field is currently set in Configuration.**
- transfer()
- renew()
- getInfo()
- updateRegistrantContact()
- updateNameservers()
- getEppCode()

The following operations aren't supported by Norid:

- setLock()
- setAutoRenew()
- updateIpsTag()