### PR TITLE
Remove incorrect status from lock logic

### DIFF
--- a/src/Hexonet/Provider.php
+++ b/src/Hexonet/Provider.php
@@ -468,7 +468,6 @@ class Provider extends DomainNames implements ProviderInterface
         $lockedStatuses = [
             'clientTransferProhibited',
             'clientUpdateProhibited',
-            'clientDeleteProhibited',
         ];
         $domainInfo['locked'] = boolval(array_intersect($lockedStatuses, $domainInfo['statuses']));
 
@@ -623,7 +622,7 @@ class Provider extends DomainNames implements ProviderInterface
     /**
      * Unlocks/Locks a domain for update, delete + transfer.
      *
-     * Toggles ClientProhibitedTransfer, clientUpdateProhibited + clientDeleteProhibited statuses of a domain.
+     * Toggles ClientProhibitedTransfer + clientUpdateProhibited statuses of a domain.
      *
      * @throws \Exception
      * @throws \Metaregistrar\EPP\eppException
@@ -642,7 +641,6 @@ class Provider extends DomainNames implements ProviderInterface
             $lockedStatuses = [
                 'clientTransferProhibited',
                 'clientUpdateProhibited',
-                'clientDeleteProhibited',
             ];
 
             $params = [


### PR DESCRIPTION
clientDeleteProhibited should not be conflated with domain locking.